### PR TITLE
[YB-51] Button, Divider, label, segmentControl을 구현합니다

### DIFF
--- a/Projects/DesignSystem/Sources/App/DesignSystemBaseViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/App/DesignSystemBaseViewController+Demo.swift
@@ -16,6 +16,7 @@ open class DesignSystemBaseViewController: UIViewController {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.distribution = .fill
+        stackView.spacing = 10
         return stackView
     }()
     

--- a/Projects/DesignSystem/Sources/App/DesignSystemViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/App/DesignSystemViewController+Demo.swift
@@ -5,6 +5,7 @@ enum Component: String, CaseIterable {
     case textField = "textField"
     case button = "button"
     case divider = "divider"
+    case segmentControl = "segmentControl"
 }
 
 public class DesignSystemViewController: UITableViewController {
@@ -44,6 +45,8 @@ extension DesignSystemViewController {
             self.navigationController?.pushViewController(ButtonViewController(), animated: true)
         case .divider:
             self.navigationController?.pushViewController(DividerViewController(), animated: true)
+        case .segmentControl:
+            self.navigationController?.pushViewController(SegmentControlViewController(), animated: true)
         }
     }
 }

--- a/Projects/DesignSystem/Sources/App/DesignSystemViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/App/DesignSystemViewController+Demo.swift
@@ -4,6 +4,7 @@ import UIKit
 enum Component: String, CaseIterable {
     case textField = "textField"
     case button = "button"
+    case divider = "divider"
 }
 
 public class DesignSystemViewController: UITableViewController {
@@ -41,6 +42,8 @@ extension DesignSystemViewController {
             self.navigationController?.pushViewController(TextFieldViewController(), animated: true)
         case .button:
             self.navigationController?.pushViewController(ButtonViewController(), animated: true)
+        case .divider:
+            self.navigationController?.pushViewController(DividerViewController(), animated: true)
         }
     }
 }

--- a/Projects/DesignSystem/Sources/App/DesignSystemViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/App/DesignSystemViewController+Demo.swift
@@ -39,6 +39,8 @@ extension DesignSystemViewController {
         switch components[indexPath.row] {
         case .textField:
             self.navigationController?.pushViewController(TextFieldViewController(), animated: true)
+        case .button:
+            self.navigationController?.pushViewController(ButtonViewController(), animated: true)
         }
     }
 }

--- a/Projects/DesignSystem/Sources/App/DesignSystemViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/App/DesignSystemViewController+Demo.swift
@@ -3,6 +3,7 @@ import UIKit
 
 enum Component: String, CaseIterable {
     case textField = "textField"
+    case button = "button"
 }
 
 public class DesignSystemViewController: UITableViewController {

--- a/Projects/DesignSystem/Sources/Button/ButtonViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/Button/ButtonViewController+Demo.swift
@@ -1,0 +1,53 @@
+//
+//  ButtonViewController.swift
+//  DesignSystem
+//
+//  Created by 이호영 on 2023/12/25.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+
+public class ButtonViewController: DesignSystemBaseViewController {
+    
+    let defaultLargeButton = YBTextButton(text: "디폴트 버튼이애옹", appearance: .default, size: .large)
+    let defaultMediumButton = YBTextButton(text: "디폴트 버튼이애옹", appearance: .default, size: .medium)
+    let defaultDisableLargeButton = YBTextButton(text: "디폴트 비활성화 버튼이애옹", appearance: .defaultDisable, size: .large)
+    let defaultDisableMediumButton = YBTextButton(text: "디폴트 비활성화 버튼이애옹", appearance: .defaultDisable, size: .medium)
+    let selectLargeButton = YBTextButton(text: "셀렉트 버튼이애옹", appearance: .select, size: .large)
+    let selectMediumButton = YBTextButton(text: "셀렉트 버튼이애옹", appearance: .select, size: .medium)
+    let selectSmallButton = YBTextButton(text: "셀렉트 버튼이애옹", appearance: .select, size: .small)
+    let selectDisableLargeButton = YBTextButton(text: "셀렉트 비활성화 버튼이애옹", appearance: .selectDisable, size: .large)
+    let selectDisableMediumButton = YBTextButton(text: "셀렉트 비활성화 버튼이애옹", appearance: .selectDisable, size: .medium)
+    let selectDisableSmallButton = YBTextButton(text: "셀렉트 비활성화 버튼이애옹", appearance: .selectDisable, size: .small)
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        self.title = "Button"
+    }
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+        
+    public override func setupView() {
+        super.setupView()
+        
+        stackView.addArrangedSubview(defaultLargeButton)
+        stackView.addArrangedSubview(defaultMediumButton)
+        stackView.addArrangedSubview(defaultDisableLargeButton)
+        stackView.addArrangedSubview(defaultDisableMediumButton)
+        stackView.addArrangedSubview(selectLargeButton)
+        stackView.addArrangedSubview(selectMediumButton)
+        stackView.addArrangedSubview(selectSmallButton)
+        stackView.addArrangedSubview(selectDisableLargeButton)
+        stackView.addArrangedSubview(selectDisableMediumButton)
+        stackView.addArrangedSubview(selectDisableSmallButton)
+    }
+}
+

--- a/Projects/DesignSystem/Sources/Button/YBTextButton.swift
+++ b/Projects/DesignSystem/Sources/Button/YBTextButton.swift
@@ -1,0 +1,102 @@
+//
+//  YBTextButton.swift
+//  DesignSystem
+//
+//  Created by 이호영 on 2023/12/25.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+
+public final class YBTextButton: UIButton {
+    
+    public init(text: String, appearance: Appearance, size: Size) {
+        super.init(frame: .zero)
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        self.heightAnchor.constraint(equalToConstant: size.height).isActive = true
+        
+        setTitle(text, for: .normal)
+        
+        configuration = configureConfiguration(appearance: appearance, size: size)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension YBTextButton {
+    
+    func configureConfiguration(appearance: Appearance, size: Size) -> Configuration {
+        var configuration: UIButton.Configuration = .filled()
+        configuration.baseBackgroundColor = appearance.backgroundColor.color
+        configuration.baseForegroundColor = appearance.textColor.color
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer (
+            { incoming in
+                var outgoing = incoming
+                outgoing.font = size.font.font
+                return outgoing
+            }
+        )
+        configuration.background.cornerRadius = size.cornerRadius
+        configuration.background.strokeWidth = 1.0
+        return configuration
+    }
+}
+
+public extension YBTextButton {
+    enum Appearance {
+        case `default`
+        case defaultDisable
+        case select
+        case selectDisable
+    }
+    
+    enum Size {
+        case large
+        case medium
+        case small
+    }
+}
+
+extension YBTextButton.Appearance {
+    
+    var textColor: YBColor {
+        switch self {
+        case .default, .select: return .white
+        case .defaultDisable: return .gray5
+        case .selectDisable: return .gray4
+        }
+    }
+    
+    var backgroundColor: YBColor {
+        switch self {
+        case .default: return .black
+        case .defaultDisable, .selectDisable: return .gray2
+        case .select: return .gray6
+        }
+    }
+}
+
+extension YBTextButton.Size {
+    
+    var font: YBFont {
+        switch self {
+        case .large: return .title1
+        case .medium: return .title1
+        case .small: return .body1
+        }
+    }
+    
+    var height: CGFloat {
+        switch self {
+        case .large, .medium: return 54
+        case .small: return 44
+        }
+    }
+    
+    var cornerRadius: CGFloat {
+        return 10
+    }
+}

--- a/Projects/DesignSystem/Sources/Button/YBTextButton.swift
+++ b/Projects/DesignSystem/Sources/Button/YBTextButton.swift
@@ -10,15 +10,19 @@ import UIKit
 
 public final class YBTextButton: UIButton {
     
+    let size: Size
+    var appearance: Appearance
+    
     public init(text: String, appearance: Appearance, size: Size) {
+        self.size = size
+        self.appearance = appearance
         super.init(frame: .zero)
         
         translatesAutoresizingMaskIntoConstraints = false
         self.heightAnchor.constraint(equalToConstant: size.height).isActive = true
         
         setTitle(text, for: .normal)
-        
-        configuration = configureConfiguration(appearance: appearance, size: size)
+        configureConfiguration()
     }
     
     required init?(coder: NSCoder) {
@@ -28,20 +32,28 @@ public final class YBTextButton: UIButton {
 
 private extension YBTextButton {
     
-    func configureConfiguration(appearance: Appearance, size: Size) -> Configuration {
-        var configuration: UIButton.Configuration = .filled()
-        configuration.baseBackgroundColor = appearance.backgroundColor.color
-        configuration.baseForegroundColor = appearance.textColor.color
-        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer (
-            { incoming in
+    func configureConfiguration() {
+        var ybConfiguration: UIButton.Configuration = .filled()
+        ybConfiguration.baseBackgroundColor = appearance.backgroundColor.color
+        ybConfiguration.baseForegroundColor = appearance.textColor.color
+        ybConfiguration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer (
+            { [weak self] incoming in
                 var outgoing = incoming
-                outgoing.font = size.font.font
+                outgoing.font = self?.size.font.font
                 return outgoing
             }
         )
-        configuration.background.cornerRadius = size.cornerRadius
-        configuration.background.strokeWidth = 1.0
-        return configuration
+        ybConfiguration.background.cornerRadius = size.cornerRadius
+        ybConfiguration.background.strokeWidth = 1.0
+        configuration = ybConfiguration
+    }
+}
+
+public extension YBTextButton {
+    
+    func setAppearance(appearance: Appearance) {
+        self.appearance = appearance
+        configureConfiguration()
     }
 }
 

--- a/Projects/DesignSystem/Sources/Divider/DividerViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/Divider/DividerViewController+Demo.swift
@@ -1,0 +1,42 @@
+//
+//  DividerViewController.swift
+//  DesignSystem
+//
+//  Created by 이호영 on 2023/12/25.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+
+public class DividerViewController: DesignSystemBaseViewController {
+    
+    let gray3Divider = YBDivider(height: 1, color: .gray3)
+    let gray2Divider = YBDivider(height: 1, color: .gray2)
+    let gray3LargeDivider = YBDivider(height: 10, color: .gray3)
+    let gray2LargeDivider = YBDivider(height: 10, color: .gray2)
+    let dotDivider = YBDivider(.dotLine, height: 1, color: .gray4)
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        self.title = "Button"
+    }
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+        
+    public override func setupView() {
+        super.setupView()
+        
+        stackView.addArrangedSubview(gray3Divider)
+        stackView.addArrangedSubview(gray2Divider)
+        stackView.addArrangedSubview(gray3LargeDivider)
+        stackView.addArrangedSubview(gray2LargeDivider)
+        stackView.addArrangedSubview(dotDivider)
+    }
+}

--- a/Projects/DesignSystem/Sources/Divider/YBDivider.swift
+++ b/Projects/DesignSystem/Sources/Divider/YBDivider.swift
@@ -1,0 +1,46 @@
+//
+//  YBDivider.swift
+//  DesignSystem
+//
+//  Created by 이호영 on 2023/12/25.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+
+public final class YBDivider: UIView {
+    
+    private let borderLayer = CAShapeLayer()
+    
+    public enum DividerType {
+        case line
+        case dotLine
+    }
+    
+    public init(_ type: DividerType = .line, height: CGFloat, color: YBColor) {
+        super.init(frame: .zero)
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        self.heightAnchor.constraint(equalToConstant: height).isActive = true
+        
+        if case type = .dotLine {
+            borderLayer.strokeColor = color.color.cgColor
+            borderLayer.lineDashPattern = [4, 4]
+            borderLayer.backgroundColor = UIColor.clear.cgColor
+            borderLayer.fillColor = UIColor.clear.cgColor
+            
+            let path = CGMutablePath()
+            path.addLines(between: [CGPoint(x: 0, y: 0),
+                                    CGPoint(x: 300, y: 0)])
+            
+            borderLayer.path = path
+            layer.addSublayer(borderLayer)
+        } else {
+            self.backgroundColor = color.color
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Projects/DesignSystem/Sources/Label/YBLabel.swift
+++ b/Projects/DesignSystem/Sources/Label/YBLabel.swift
@@ -1,0 +1,51 @@
+//
+//  YBLabel.swift
+//  DesignSystem
+//
+//  Created by 이호영 on 2023/12/25.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+
+public final class YBLabel: UILabel {
+    
+    public init(text: String,
+                font: YBFont,
+                textColor: YBColor = .black,
+                textAlignment: NSTextAlignment = .left
+    ) {
+        super.init(frame: .zero)
+        
+        self.font = font.font
+        self.textColor = textColor.color
+        self.text = text
+        self.textAlignment = textAlignment
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+public extension YBLabel {
+     
+    /// 행간이 추가되어야하는 경우 사용
+    func setLineHeight(lineHeight: CGFloat) {
+        if let text = self.text {
+            let style = NSMutableParagraphStyle()
+            style.maximumLineHeight = lineHeight
+            style.minimumLineHeight = lineHeight
+            style.alignment = self.textAlignment
+            
+            let attributes: [NSAttributedString.Key: Any] = [
+                .paragraphStyle: style,
+                .baselineOffset: (lineHeight - font.lineHeight) / 4,
+            ]
+                
+            let attrString = NSAttributedString(string: text,
+                                                attributes: attributes)
+            self.attributedText = attrString
+        }
+    }
+}

--- a/Projects/DesignSystem/Sources/SegmentControl/SegmentControlViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/SegmentControl/SegmentControlViewController+Demo.swift
@@ -1,0 +1,34 @@
+//
+//  SegmentControlViewController.swift
+//  DesignSystem
+//
+//  Created by 이호영 on 2023/12/25.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public class SegmentControlViewController: DesignSystemBaseViewController {
+    
+    let ybRoundSegmentControl = YBSegmentControl(.round, items: ["공동", "개인"])
+    let ybRectangleSegmentControl = YBSegmentControl(.rectangle ,items: ["지출 추가", "공동 경비 추가"])
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        self.title = "segmentControl"
+    }
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        
+        stackView.addArrangedSubview(ybRoundSegmentControl)
+        stackView.addArrangedSubview(ybRectangleSegmentControl)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/Projects/DesignSystem/Sources/SegmentControl/YBSegmentControl.swift
+++ b/Projects/DesignSystem/Sources/SegmentControl/YBSegmentControl.swift
@@ -1,0 +1,74 @@
+//
+//  YBRoundSegmentControl.swift
+//  DesignSystem
+//
+//  Created by 이호영 on 2023/12/25.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public class YBSegmentControl: UISegmentedControl {
+    
+    public enum SegmentControlType {
+        case round
+        case rectangle
+    }
+    
+    let type: SegmentControlType
+    
+    public init(_ type: SegmentControlType, items: [String]) {
+        self.type = type
+        super.init(items: items)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        layer.cornerRadius = type == .round ? 20 : 10
+        layer.masksToBounds = true
+        backgroundColor = YBColor.gray2.color
+        
+        let foregroundIndex = numberOfSegments
+        if subviews.indices.contains(foregroundIndex),
+           let foregroundImageView = subviews[foregroundIndex] as? UIImageView {
+
+            foregroundImageView.image = UIImage()
+            foregroundImageView.backgroundColor = YBColor.white.color
+            foregroundImageView.bounds = foregroundImageView.bounds.insetBy(dx: 6.0,
+                                                                            dy: 6.0)
+            foregroundImageView.layer.removeAnimation(forKey: "SelectionBounds")
+            foregroundImageView.layer.cornerRadius = type == .round ? 20 : 10
+        }
+        
+        let imageViews = self.subviews.filter({ $0 is UIImageView }).compactMap({ $0 as? UIImageView })
+        for imageView in Array(imageViews[..<self.numberOfSegments]) {
+            imageView.isHidden = true
+        }
+    }
+}
+
+private extension YBSegmentControl {
+    
+    func configureUI() {
+        translatesAutoresizingMaskIntoConstraints = false
+        self.heightAnchor.constraint(equalToConstant: 38).isActive = true
+        
+        self.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: YBColor.black.color,
+                                     NSAttributedString.Key.font: YBFont.body3.font],
+                                    for: .selected)
+        self.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: YBColor.gray5.color,
+                                     NSAttributedString.Key.font: YBFont.body3.font],
+                                    for: .normal)
+        
+        self.selectedSegmentIndex = 0
+        self.backgroundColor = .clear
+    }
+}
+


### PR DESCRIPTION
## 이슈번호
[YB-51]

## 수정 사항
### Button
<img width="722" alt="스크린샷 2023-12-25 오후 7 41 25" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/40068674/d091098d-b4d9-4813-b66e-791bd754b04e">

- 디자인 시스템 기반으로 YBTextButton을 정의했습니다
- 디자인 변동사항이 많을 것 같아서 Default TextButton, select button만 구현했습니다
- appearance가 바뀌는 경우를 위해서 setAppearance 메서드도 구현했습니다
`defaultLargeButton.setAppearance(appearance: .default)`

### Divider
- YBDivider를 정의하였습니다
- 실선은 약간 문제가 있는데 contraint로 해결할 것 같아서 올렷습니당

### Label
-YBLabel을 정의하였습니다

### SegmentControl
- 화면에서 사용하는 SegmentControl을 round, rectangel type으로 구분되게 구현하였습니다

## 화면 (Optional)
| Button | Divider | SegmentControl |
| --- | --- | --- |
| <img width="357" alt="스크린샷 2023-12-25 오후 7 43 01" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/40068674/729fa86d-e800-4dd7-b178-75accfaf4969"> | <img width="361" alt="스크린샷 2023-12-25 오후 9 48 15" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/40068674/c02d8dd3-e06c-49f8-aa93-41c34b511738"> | <img width="353" alt="스크린샷 2023-12-25 오후 9 47 17" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/40068674/3c50d8e4-e288-4b1a-a733-61d269564824"> |

## target module
Design System

## 참고사항
- 코드가 따로 올리면 충돌나서 같이 올렸습니다ㅠ
- 자꾸 커밋올라가서 죄송해용..

[YB-51]: https://yeobee.atlassian.net/browse/YB-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ