### PR TITLE
[YB-64] 외부 의존성 수정 (#9)

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -1,21 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "flexlayout",
+      "identity" : "snapkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/layoutBox/FlexLayout.git",
+      "location" : "https://github.com/SnapKit/SnapKit",
       "state" : {
-        "branch" : "master",
-        "revision" : "c564935d2a24da7bd0b426132d0727cf20c8ecfe"
-      }
-    },
-    {
-      "identity" : "pinlayout",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/layoutBox/PinLayout.git",
-      "state" : {
-        "branch" : "master",
-        "revision" : "8eaa3a15e4dcabaca4c95aea4c0ff0c9b4a67213"
+        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
+        "version" : "5.6.0"
       }
     }
   ],

--- a/Projects/DesignSystem/Project.swift
+++ b/Projects/DesignSystem/Project.swift
@@ -21,8 +21,7 @@ let project = Project(
                 ]
               ),
             dependencies: [
-                .package(product: "FlexLayout"),
-                .package(product: "PinLayout")
+                .SnapKit
             ]
         ),
         Project.target(

--- a/Projects/Features/Sign/Project.swift
+++ b/Projects/Features/Sign/Project.swift
@@ -7,8 +7,7 @@ let project = Project(
     options: .options(
         automaticSchemesOptions: .disabled
     ),
-    packages: [
-    ],
+    packages: [],
     settings: .settings(configurations: [
         .debug(name: .debug),
         .release(name: .release),

--- a/Projects/YeoBee/Project.swift
+++ b/Projects/YeoBee/Project.swift
@@ -11,8 +11,7 @@ let project = Project(
         automaticSchemesOptions: .disabled
     ),
     packages: [
-        .pinLayout,
-        .flexLayout,
+        .SnapKit
     ],
     settings: .settings(configurations: [
         .debug(name: .debug),

--- a/Tuist/ProjectDescriptionHelpers/TargetDependencyExtension.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependencyExtension.swift
@@ -34,8 +34,7 @@ public extension TargetDependency {
     static let RxCocoa: TargetDependency = .external(name: "RxCocoa")
     static let moya: TargetDependency = .external(name: "Moya")
     static let reactorKit: TargetDependency = .external(name: "ReactorKit")
-    static let flexLayout: TargetDependency = .external(name: "FlexLayout")
-    static let pinLayout: TargetDependency = .external(name: "PinLayout")
+    static let SnapKit: TargetDependency = .package(product: "SnapKit")
     static let fscalendar: TargetDependency = .external(name: "FSCalendar")
 }
 
@@ -43,8 +42,7 @@ public extension Package {
     static let RxSwift = Package.remote(url: "https://github.com/ReactiveX/RxSwift", requirement: .upToNextMajor(from: "6.2.0"))
     static let moya: Package = .remote(url: "https://github.com/Moya/Moya.git", requirement: .branch("master"))
     static let reactorKit: Package = .remote(url: "https://github.com/ReactorKit/ReactorKit.git", requirement: .branch("master"))
-    static let flexLayout: Package = .remote(url: "https://github.com/layoutBox/FlexLayout.git", requirement: .branch("master"))
-    static let pinLayout: Package = .remote(url: "https://github.com/layoutBox/PinLayout.git", requirement: .branch("master"))
+    static let SnapKit: Package = .remote(url: "https://github.com/SnapKit/SnapKit.git", requirement: .upToNextMajor(from: "5.0.1"))
     static let fscalendar: Package = .remote(url: "https://github.com/WenchaoD/FSCalendar.git", requirement: .branch("master"))
 }
 


### PR DESCRIPTION
## 이슈번호
[YB-64]


## target module
DesignSystem

## 참고사항
기존 의존성 구성과 동일하게 FlexLayout, PinLayout 대신 SnapKit으로 대체했습니다.
DesignSystem에 의존되어 있는 만큼 SnapKit 사용 시  DesignSystem을 import 해야 사용 가능합니다! 

[YB-64]: https://yeobee.atlassian.net/browse/YB-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ