### PR TITLE
[YB-69] 지출 내역 화면의 총 쓴돈을 나타내는 영역을 SwiftUI로 그립니다

### DIFF
--- a/Projects/DesignSystem/Sources/Divider/YBDividerView+SwiftUI.swift
+++ b/Projects/DesignSystem/Sources/Divider/YBDividerView+SwiftUI.swift
@@ -1,0 +1,25 @@
+//
+//  YBDividerView+SwiftUI.swift
+//  DesignSystem
+//
+//  Created by Hoyoung Lee on 12/29/23.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import SwiftUI
+
+public struct YBDividerView: View {
+    let color: YBColor
+    let height: CGFloat
+
+    public init(color: YBColor = .gray3, height: CGFloat = 1) {
+        self.color = color
+        self.height = height
+    }
+
+    public var body: some View {
+        Rectangle()
+            .frame(height: height)
+            .foregroundColor(color.swiftUIColor)
+    }
+}

--- a/Projects/Features/Expenditure/Sources/CommonView/LargeTotalPriceView.swift
+++ b/Projects/Features/Expenditure/Sources/CommonView/LargeTotalPriceView.swift
@@ -1,0 +1,27 @@
+//
+//  LargeTotalPriceView.swift
+//  Expenditure
+//
+//  Created by Hoyoung Lee on 12/29/23.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct LargeTotalPriceView: View {
+    let title: String
+    let price: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .foregroundColor(.ybColor(.gray5))
+                .font(.ybfont(.body3))
+
+            Text(price)
+                .foregroundColor(.ybColor(.black))
+                .font(.ybfont(.header1))
+        }
+    }
+}

--- a/Projects/Features/Expenditure/Sources/CommonView/SmallTotalPriceView.swift
+++ b/Projects/Features/Expenditure/Sources/CommonView/SmallTotalPriceView.swift
@@ -26,13 +26,16 @@ struct SmallTotalPriceView: View {
                 .foregroundColor(titleColor.swiftUIColor)
                 .font(.ybfont(.body3))
             Spacer()
-            Text(price)
-                .foregroundColor(.ybColor(.gray6))
-                .font(.ybfont(.body3))
-                .lineLimit(1)
-            Text("원")
-                .foregroundColor(.ybColor(.gray6))
-                .font(.ybfont(.body3))
+            HStack(spacing: 0) {
+                Text(price)
+                    .foregroundColor(.ybColor(.gray6))
+                    .font(.ybfont(.body3))
+                    .lineLimit(1)
+                Text("원")
+                    .foregroundColor(.ybColor(.gray6))
+                    .font(.ybfont(.body3))
+            }
+
         }
     }
 }

--- a/Projects/Features/Expenditure/Sources/CommonView/SmallTotalPriceView.swift
+++ b/Projects/Features/Expenditure/Sources/CommonView/SmallTotalPriceView.swift
@@ -1,0 +1,38 @@
+//
+//  SmallTotalPriceView.swift
+//  Expenditure
+//
+//  Created by Hoyoung Lee on 12/29/23.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct SmallTotalPriceView: View {
+    let title: String
+    let price: String
+    let titleColor: YBColor
+
+    init(title: String, titleColor: YBColor = .gray4, price: String) {
+        self.title = title
+        self.price = price
+        self.titleColor = titleColor
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .foregroundColor(titleColor.swiftUIColor)
+                .font(.ybfont(.body3))
+            Spacer()
+            Text(price)
+                .foregroundColor(.ybColor(.gray6))
+                .font(.ybfont(.body3))
+                .lineLimit(1)
+            Text("원")
+                .foregroundColor(.ybColor(.gray6))
+                .font(.ybfont(.body3))
+        }
+    }
+}

--- a/Projects/Features/Expenditure/Sources/ExpenditureListViewController/ExpenditureListViewController.swift
+++ b/Projects/Features/Expenditure/Sources/ExpenditureListViewController/ExpenditureListViewController.swift
@@ -52,6 +52,7 @@ public final class ExpenditureListViewController: UIViewController {
 
     func setupViews() {
         title = "일본 여행"
+        view.backgroundColor = .ybColor(.gray1)
     }
 
     func setLayouts() {

--- a/Projects/Features/Expenditure/Sources/HostingController/ExpenditureListView.swift
+++ b/Projects/Features/Expenditure/Sources/HostingController/ExpenditureListView.swift
@@ -29,10 +29,18 @@ extension ExpenditureListView {
     var containerView: some View {
         ScrollView(showsIndicators: false) {
             VStack {
-                
+                TotalPriceView(
+                    store: store.scope(
+                        state: \.totalPrice,
+                        action: ExpenditureListReducer.Action.totalPrice
+                    )
+                )
+                .padding(20)
             }
             .background(YBColor.white.swiftUIColor)
             .cornerRadius(10)
+            .padding(18)
         }
+        .background(YBColor.gray1.swiftUIColor)
     }
 }

--- a/Projects/Features/Expenditure/Sources/TotalPrice/TotalPriceReducer.swift
+++ b/Projects/Features/Expenditure/Sources/TotalPrice/TotalPriceReducer.swift
@@ -1,5 +1,5 @@
 //
-//  ExpenditureListReducer.swift
+//  TotalPriceReducer.swift
 //  Expenditure
 //
 //  Created Hoyoung Lee on 12/29/23.
@@ -8,24 +8,21 @@
 import Combine
 import ComposableArchitecture
 
-public struct ExpenditureListReducer: Reducer {
+public struct TotalPriceReducer: Reducer {
     public struct State: Equatable {
-        var totalPrice = TotalPriceReducer.State()
+        var totalExpandPrice: Int = 1000
+        var totalBudgetPrice: Int = 100000000000000
+        var remainBudgetPrice: Int = 1000000000
     }
 
     public enum Action {
-        case totalPrice(TotalPriceReducer.Action)
     }
 
-    public var body: some ReducerOf<ExpenditureListReducer> {
+    public var body: some ReducerOf<TotalPriceReducer> {
         Reduce { _, action in
             switch action {
                 default: return .none
             }
-        }
-
-        Scope(state: \.totalPrice, action: /Action.totalPrice) {
-            TotalPriceReducer()
         }
     }
 }

--- a/Projects/Features/Expenditure/Sources/TotalPrice/TotalPriceView.swift
+++ b/Projects/Features/Expenditure/Sources/TotalPrice/TotalPriceView.swift
@@ -1,0 +1,65 @@
+//
+//  TotalPriceView.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 12/29/23.
+//  Copyright © 2023 YeoBee.com. All rights reserved.
+
+import SwiftUI
+import ComposableArchitecture
+
+import DesignSystem
+
+struct TotalPriceView: View {
+    typealias State = TotalPriceReducer.State
+    typealias Action = TotalPriceReducer.Action
+
+    let store: StoreOf<TotalPriceReducer>
+
+    var body: some View {
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            VStack {
+                if viewStore.totalBudgetPrice <= 0 {
+                    totalExpandPriceView(price: viewStore.totalExpandPrice)
+                } else {
+                    budgetPriceView(
+                        totalExpandPrice: viewStore.totalExpandPrice,
+                        totalBudgetPrice: viewStore.totalBudgetPrice,
+                        remainBudgetPrice: viewStore.remainBudgetPrice
+                    )
+                }
+            }
+        }
+    }
+}
+
+extension TotalPriceView {
+    func totalExpandPriceView(price: Int) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LargeTotalPriceView(title: "총쓴돈", price: "\(price)원")
+            YBDividerView()
+        }
+    }
+
+    func budgetPriceView(
+        totalExpandPrice: Int,
+        totalBudgetPrice: Int,
+        remainBudgetPrice: Int
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LargeTotalPriceView(title: "예산 잔액", price: "\(remainBudgetPrice)원")
+            YBDividerView()
+            HStack(spacing: 8) {
+                SmallTotalPriceView(title: "총예산", price: "\(totalBudgetPrice)원")
+                verticalDividerView
+                SmallTotalPriceView(title: "총쓴돈", titleColor: .mainRed, price: "\(totalExpandPrice)원")
+            }
+        }
+    }
+
+    var verticalDividerView: some View {
+        Rectangle()
+            .frame(width: 1)
+            .foregroundColor(.ybColor(.gray3))
+    }
+}

--- a/Projects/Features/Expenditure/Sources/TotalPrice/TotalPriceView.swift
+++ b/Projects/Features/Expenditure/Sources/TotalPrice/TotalPriceView.swift
@@ -53,6 +53,7 @@ extension TotalPriceView {
                 SmallTotalPriceView(title: "총예산", price: "\(totalBudgetPrice)원")
                 verticalDividerView
                 SmallTotalPriceView(title: "총쓴돈", titleColor: .mainRed, price: "\(totalExpandPrice)원")
+                YBDividerView()
             }
         }
     }

--- a/Projects/Features/Expenditure/Sources/TotalPrice/TotalPriceView.swift
+++ b/Projects/Features/Expenditure/Sources/TotalPrice/TotalPriceView.swift
@@ -50,11 +50,11 @@ extension TotalPriceView {
             LargeTotalPriceView(title: "예산 잔액", price: "\(remainBudgetPrice)원")
             YBDividerView()
             HStack(spacing: 8) {
-                SmallTotalPriceView(title: "총예산", price: "\(totalBudgetPrice)원")
+                SmallTotalPriceView(title: "총예산", price: "\(totalBudgetPrice)")
                 verticalDividerView
-                SmallTotalPriceView(title: "총쓴돈", titleColor: .mainRed, price: "\(totalExpandPrice)원")
-                YBDividerView()
+                SmallTotalPriceView(title: "총쓴돈", titleColor: .mainRed, price: "\(totalExpandPrice)")
             }
+            YBDividerView()
         }
     }
 


### PR DESCRIPTION
## 이슈번호
[YB-69]

## 수정 사항
- 총 쓴돈 영역을 SwiftUI+TCA로 다시 그렸습니다
- SwiftUI 잘 모르실텐데ㅠㅠ 최대한 깔끔하게 그려서 리뷰하기 편하게 만들었습니다

## 화면 (Optional)
| scene name |
| --- |
| <img width="348" alt="스크린샷 2023-12-29 오후 11 36 34" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/40068674/f2f14892-5ef5-4493-90e7-e89cf194f1a6"> |

## target module
Expenditure

## 참고사항
질문 있으시면 언제든 물어봐주세용

[YB-69]: https://yeobee.atlassian.net/browse/YB-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ