### PR TITLE
[YB-78] 캘린더 화면 구현

### DIFF
--- a/Projects/DesignSystem/Sources/Button/YBIconButton.swift
+++ b/Projects/DesignSystem/Sources/Button/YBIconButton.swift
@@ -1,0 +1,30 @@
+//
+//  YBIconButton.swift
+//  DesignSystem
+//
+//  Created by 박현준 on 1/7/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+
+public final class YBIconButton: UIButton {
+    
+    public init(image: UIImage?, tintColor: YBColor? = nil) {
+        super.init(frame: .zero)
+        configure(image: image, tintColor: tintColor)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configure(image: UIImage?, tintColor: YBColor? = nil) {
+        if let color = tintColor {
+            let img = image?.withTintColor(color.color, renderingMode: .alwaysOriginal)
+            self.setImage(img, for: .normal)
+        } else {
+            self.setImage(image, for: .normal)
+        }
+    }
+}

--- a/Projects/DesignSystem/Sources/Button/YBPaddingButton.swift
+++ b/Projects/DesignSystem/Sources/Button/YBPaddingButton.swift
@@ -51,6 +51,8 @@ public final class YBPaddingButton: UIButton {
             layer.cornerRadius = 16
         case .large:
             layer.cornerRadius = 18
+        case .calendarDate:
+            layer.cornerRadius = 16
         case .custom:
             layer.cornerRadius = 15
         }
@@ -72,6 +74,7 @@ public enum Padding {
     case small
     case medium
     case large
+    case calendarDate
     case custom(top: CGFloat, left: CGFloat, bottom: CGFloat, right: CGFloat)
     
     var insets: UIEdgeInsets {
@@ -82,6 +85,8 @@ public enum Padding {
             return UIEdgeInsets(top: 7, left: 20, bottom: 7, right: 20)
         case .large:
             return UIEdgeInsets(top: 12, left: 24, bottom: 12, right: 24)
+        case .calendarDate:
+            return UIEdgeInsets(top: 7.5, left: 14, bottom: 7.5, right: 14)
         case .custom(let top, let left, let bottom, let right):
             return UIEdgeInsets(top: top, left: left, bottom: bottom, right: right)
         }

--- a/Projects/DesignSystem/Sources/Label/YBPaddingLabel.swift
+++ b/Projects/DesignSystem/Sources/Label/YBPaddingLabel.swift
@@ -1,0 +1,69 @@
+//
+//  YBPaddingLabel.swift
+//  DesignSystem
+//
+//  Created by 박현준 on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+
+public final class YBPaddingLabel: UILabel {
+    
+    private let padding: UIEdgeInsets
+    
+    public init(text: String, backgroundColor: YBColor, textColor: YBColor, 
+                borderColor: YBColor? = nil, font: YBFont, textAlignment: NSTextAlignment = .center, padding: Padding = .calendarDate) {
+        self.padding = padding.insets
+        super.init(frame: .zero)
+        self.text = text
+        self.textAlignment = textAlignment
+        configure(bgColor: backgroundColor,
+                  txtColor: textColor,
+                  brdColor: borderColor,
+                  ft: font,
+                  padding: padding)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect.inset(by: padding))
+    }
+    
+    public override var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        if contentSize == .zero { return contentSize }
+        contentSize.height += padding.top + padding.bottom
+        contentSize.width += padding.left + padding.right
+        return contentSize
+    }
+    
+    func configure(bgColor: YBColor, txtColor: YBColor, brdColor: YBColor? = nil, ft: YBFont, padding: Padding) {
+        self.backgroundColor = bgColor.color
+        self.textColor = txtColor.color
+        self.font = ft.font
+        
+        if brdColor != nil {
+            self.layer.borderColor = brdColor?.color.cgColor
+            self.layer.borderWidth = 0.6
+        }
+        
+        switch padding {
+        case .small:
+            layer.cornerRadius = 14
+        case .medium:
+            layer.cornerRadius = 16
+        case .large:
+            layer.cornerRadius = 18
+        case .calendarDate:
+            layer.cornerRadius = 16
+        case .custom:
+            layer.cornerRadius = 15
+        }
+        clipsToBounds = true
+    }
+}

--- a/Projects/Features/Home/Project.swift
+++ b/Projects/Features/Home/Project.swift
@@ -22,8 +22,7 @@ let project = Project(
                 .RxSwift,
                 .RxCocoa,
                 .RxGesture,
-                .reactorKit,
-                .fscalendar
+                .reactorKit
             ]
         ),
         Project.target(

--- a/Projects/Features/TravelRegistration/Project.swift
+++ b/Projects/Features/TravelRegistration/Project.swift
@@ -22,7 +22,8 @@ let project = Project(
                 .RxSwift,
                 .RxCocoa,
                 .RxGesture,
-                .reactorKit
+                .reactorKit,
+                .fscalendar
             ]
         ),
         Project.target(

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarReactor.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarReactor.swift
@@ -1,0 +1,68 @@
+//
+//  CalendarReactor.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+import ReactorKit
+import RxSwift
+import RxCocoa
+
+public final class CalendarReactor: Reactor {
+    
+    public enum Action {
+        case startDate(date: Date?)
+        case endDate(date: Date?)
+        case selectedDate(dates: [Date])
+    }
+    
+    public enum Mutation {
+        case startDate(date: Date?)
+        case endDate(date: Date?)
+        case selectedDate(dates: [Date])
+    }
+    
+    public struct State {
+        var startDate: Date? = nil
+        var endDate: Date? = nil
+        var selectedDate: [Date] = []
+    }
+    
+    public var initialState: State = State()
+    
+    // MARK: - Mutate
+    public func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .startDate(date: let date):
+            return .just(Mutation.startDate(date: date ?? nil))
+        case .endDate(date: let date):
+            return .just(Mutation.endDate(date: date ?? nil))
+        case .selectedDate(dates: let dates):
+            return .just(Mutation.selectedDate(dates: dates))
+        }
+    }
+    
+    // MARK: Reduce
+    public func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+    
+        switch mutation {
+        case .startDate(date: let date):
+            newState.startDate = date
+            if let date = date {
+                newState.selectedDate.append(date)
+            } else {
+                newState.selectedDate.removeAll()
+            }
+        case .endDate(date: let date):
+            newState.endDate = date
+        case .selectedDate(dates: let dates):
+            newState.selectedDate.append(contentsOf: dates)
+        }
+        
+        return newState
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarViewController.swift
@@ -1,0 +1,309 @@
+//
+//  CalendarViewController.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+import ReactorKit
+import RxSwift
+import RxCocoa
+import SnapKit
+import FSCalendar
+
+public final class CalendarViewController: TravelRegistrationController {
+    
+    public var disposeBag = DisposeBag()
+    private let reactor = CalendarReactor()
+    
+    private var dateformatter: DateFormatter = {
+        $0.dateFormat = "MM.dd E"
+        $0.locale = Locale(identifier: "ko_KR")
+        return $0
+    }(DateFormatter())
+    
+    // MARK: - Properties
+    private let registerLabel = YBLabel(text: "여행일정을 등록해주세요.", 
+                                        font: .header2,
+                                        textColor: .black,
+                                        textAlignment: .left)
+    private lazy var periodLabel = YBPaddingLabel(text: " - ",
+                                                  backgroundColor: .brightGreen,
+                                                  textColor: .mainGreen,
+                                                  borderColor: .mediumGreen,
+                                                  font: .body2)
+    private let calendarView = CalendarView()
+    private let dividerView = YBDivider(height: 0.6, 
+                                        color: .gray3)
+    private let nextButton = YBTextButton(text: "다음으로", 
+                                          appearance: .defaultDisable,
+                                          size: .medium)
+    // MARK: - Life Cycles
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        addViews()
+        setLayouts()
+        setDelegate()
+        bind(reactor: reactor)
+    }
+    
+    // MARK: - Set UI
+    private func addViews() {
+        [
+            registerLabel,
+            periodLabel,
+            calendarView,
+            dividerView,
+            nextButton
+        ].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    private func setLayouts() {
+        registerLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(24)
+            make.leading.equalToSuperview().inset(24)
+        }
+        periodLabel.snp.makeConstraints { make in
+            make.top.equalTo(registerLabel.snp.bottom).inset(-18)
+            make.leading.equalTo(registerLabel.snp.leading)
+        }
+        nextButton.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(10)
+            make.leading.trailing.equalToSuperview().inset(24)
+        }
+        dividerView.snp.makeConstraints { make in
+            make.bottom.equalTo(nextButton.snp.top).inset(-16)
+            make.leading.trailing.equalToSuperview()
+        }
+        calendarView.snp.makeConstraints { make in
+            make.top.equalTo(periodLabel.snp.bottom).inset(-26)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(dividerView.snp.top)
+        }
+    }
+    
+    private func setDelegate() {
+        calendarView.calendar.delegate = self
+        calendarView.calendar.dataSource = self
+    }
+}
+
+extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
+    public func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
+        configureCalenderHeaderText()
+    }
+    
+    public func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        // 아무 날짜 선택되지 않은 경우
+        if reactor.currentState.startDate == nil {
+            reactor.action.onNext(.startDate(date: date))
+            configureVisibleCells()
+            return
+        }
+        
+        // 시작 날짜만 선택된 경우
+        if reactor.currentState.startDate != nil && reactor.currentState.endDate == nil {
+            // 마지막 날짜가 시작날짜보다 작을 경우
+            if date <= reactor.currentState.startDate ?? Date() {
+                reactor.action.onNext(.startDate(date: date))
+                configureVisibleCells()
+                return
+            }
+            
+            let range = datesRange(from: reactor.currentState.startDate ?? Date(), to: date)
+            reactor.action.onNext(.endDate(date: range.last ?? Date()))
+            for d in range {
+                calendar.select(d)
+            }
+            reactor.action.onNext(.selectedDate(dates: range))
+            configureVisibleCells()
+            return
+        }
+        
+        // 시작, 마지막 날짜 모두 선택된 경우
+        if reactor.currentState.startDate != nil && reactor.currentState.endDate != nil {
+            clearSelectedDates(in: calendar)
+        }
+        configureVisibleCells()
+    }
+    
+    
+    public func calendar(_ calendar: FSCalendar, cellFor date: Date, at position: FSCalendarMonthPosition) -> FSCalendarCell {
+        let cell = calendar.dequeueReusableCell(withIdentifier: YBCalendarCell.identifier, for: date, at: position)
+        return cell
+    }
+    
+    public func calendar(_ calendar: FSCalendar, willDisplay cell: FSCalendarCell, for date: Date, at monthPosition: FSCalendarMonthPosition) {
+        self.configure(cell: cell, for: date, at: monthPosition)
+    }
+    
+    public func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
+        return monthPosition == FSCalendarMonthPosition.current
+    }
+    
+    public func calendar(_ calendar: FSCalendar, shouldDeselect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
+        return false
+    }
+    
+    public func calendar(_ calendar: FSCalendar, didDeselect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        configureVisibleCells()
+    }
+    
+    public func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, titleDefaultColorFor date: Date) -> UIColor? {
+        let day = Calendar.current.component(.weekday, from: date) - 1
+        
+        if day == 0 {
+            return YBColor.mainRed.color
+        } else {
+            return YBColor.black.color
+        }
+    }
+}
+
+// MARK: - 헤더 / 날짜 설정
+extension CalendarViewController {
+    private func configureCalenderHeaderText() {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월"
+        let currentPage = calendarView.calendar.currentPage
+        calendarView.monthHeaderLabel.text = formatter.string(from: currentPage)
+    }
+    
+    private func updatePeriodLabel(startDate: Date?, endDate: Date?) {
+        guard let startDate = startDate else { return periodLabel.text = " - " }
+        let startDateString = dateformatter.string(from: startDate)
+        guard let endDate = endDate else { return periodLabel.text = "\(startDateString) - " }
+        let endDateString = dateformatter.string(from: endDate)
+        periodLabel.text = "\(startDateString) - \(endDateString)"
+    }
+}
+
+// MARK: - 캘린더 설정
+extension CalendarViewController {
+    private func clearSelectedDates(in calendar: FSCalendar) {
+        calendar.selectedDates.forEach { calendar.deselect($0) }
+        reactor.action.onNext(.startDate(date: nil))
+        reactor.action.onNext(.endDate(date: nil))
+        reactor.action.onNext(.selectedDate(dates: []))
+    }
+    
+    private func configureVisibleCells() {
+        calendarView.calendar.visibleCells().forEach { (cell) in
+            let date = calendarView.calendar.date(for: cell)
+            let position = calendarView.calendar.monthPosition(for: cell)
+            guard let unwrappedDate = date else { return }
+            self.configure(cell: cell, for: unwrappedDate, at: position)
+        }
+    }
+    
+    private func configure(cell: FSCalendarCell, for date: Date, at position: FSCalendarMonthPosition) {
+        guard let diyCell = (cell as? YBCalendarCell) else { return }
+        diyCell.circleImageView?.isHidden = true
+        var selectionType = SelectionType.none
+        let selectedDates = calendarView.calendar.selectedDates.sorted()
+        
+        // 두 개 선택 시
+        if selectedDates.count == 2 {
+            let first = selectedDates[0]
+            let second = selectedDates[1]
+            
+            if date == first {
+                selectionType = .leftBorder
+            } else if date == second {
+                selectionType = .rightBorder
+            } else if date > first && date < second {
+                selectionType = .middle
+            }
+            // 여러 개 선택 시
+        } else if selectedDates.count > 2 {
+            if date > selectedDates.first ?? Date() && date < selectedDates.last ?? Date() {
+                selectionType = .middle
+                diyCell.titleLabel.textColor = YBColor.mainGreen.color
+            } else if date == selectedDates.last {
+                selectionType = .rightBorder
+            } else if date == selectedDates.first {
+                selectionType = .leftBorder
+            }
+        } else {
+            if calendarView.calendar.selectedDates.contains(date) {
+                // 하나 선택 시
+                if calendarView.calendar.selectedDates.count == 1 {
+                    selectionType = .single
+                } else {
+                    selectionType = .none
+                }
+            } else {
+                selectionType = .none
+            }
+        }
+        
+        diyCell.selectionLayer?.isHidden = false
+        diyCell.selectionType = selectionType
+    }
+    
+    private func datesRange(from startDate: Date, to endDate: Date) -> [Date] {
+        guard startDate <= endDate else { return [] }
+        
+        var currentDate = startDate
+        var dates = [currentDate]
+        
+        while currentDate < endDate {
+            guard let nextDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate) else { break }
+            dates.append(nextDate)
+            currentDate = nextDate
+        }
+        return dates
+    }
+}
+
+// MARK: - Bind
+extension CalendarViewController: View {
+    public func bind(reactor: CalendarReactor) {
+        bindAction(reactor: reactor)
+        bindState(reactor: reactor)
+    }
+    
+    func bindAction(reactor: CalendarReactor) {
+        nextButton.rx.tap
+            .observe(on: MainScheduler.instance)
+            .bind { _ in
+                print("nextButton Tap")
+            }.disposed(by: disposeBag)
+    }
+    
+    func bindState(reactor: CalendarReactor) {
+        reactor.state
+            .map { $0.startDate }
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] startDate in
+                self?.updatePeriodLabel(startDate: startDate, endDate: nil)
+            }.disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.endDate }
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] endDate in
+                self?.updatePeriodLabel(startDate: reactor.currentState.startDate, endDate: endDate)
+            }.disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.selectedDate }
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] selectedDate in
+                if selectedDate.isEmpty {
+                    self?.nextButton.isEnabled = false
+                    self?.nextButton.setTitle("다음으로", for: .normal)
+                    self?.nextButton.setAppearance(appearance: .defaultDisable)
+                } else {
+                    self?.nextButton.isEnabled = true
+                    self?.nextButton.setTitle("다음으로", for: .normal)
+                    self?.nextButton.setAppearance(appearance: .default)
+                }
+            }.disposed(by: disposeBag)
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/SubViews/CalendarView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/SubViews/CalendarView.swift
@@ -18,18 +18,8 @@ class CalendarView: UIView {
     
     private let dividerView = YBDivider(height: 0.6, color: .gray3)
     lazy var monthHeaderLabel = YBLabel(text: dateformatter.string(from: Date()), font: .body1, textColor: .black)
-    
-    lazy var previousMonthButton: UIButton = {
-        let image = UIImage(systemName:"chevron.backward")?.withTintColor(YBColor.black.color, renderingMode: .alwaysOriginal)
-        $0.setImage(image, for: .normal)
-        return $0
-    }(UIButton())
-    
-    lazy var nextMonthButton: UIButton = {
-        let image = UIImage(systemName:"chevron.forward")?.withTintColor(YBColor.black.color, renderingMode: .alwaysOriginal)
-        $0.setImage(image, for: .normal)
-        return $0
-    }(UIButton())
+    private let previousMonthButton = YBIconButton(image: UIImage(systemName:"chevron.backward"), tintColor: .black)
+    private let nextMonthButton = YBIconButton(image: UIImage(systemName:"chevron.forward"), tintColor: .black)
     
     lazy var calendar: FSCalendar = {
         $0.locale = Locale(identifier: "ko_KR")

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/SubViews/CalendarView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/SubViews/CalendarView.swift
@@ -1,0 +1,130 @@
+//
+//  CalendarView.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+import SnapKit
+import FSCalendar
+import RxSwift
+import RxCocoa
+
+class CalendarView: UIView {
+    var disposeBag = DisposeBag()
+    
+    private let dividerView = YBDivider(height: 0.6, color: .gray3)
+    lazy var monthHeaderLabel = YBLabel(text: dateformatter.string(from: Date()), font: .body1, textColor: .black)
+    
+    lazy var prevMonthButton: UIButton = {
+        let image = UIImage(systemName:"chevron.backward")?.withTintColor(YBColor.black.color, renderingMode: .alwaysOriginal)
+        $0.setImage(image, for: .normal)
+        return $0
+    }(UIButton())
+    
+    lazy var nextMonthButton: UIButton = {
+        let image = UIImage(systemName:"chevron.forward")?.withTintColor(YBColor.black.color, renderingMode: .alwaysOriginal)
+        $0.setImage(image, for: .normal)
+        return $0
+    }(UIButton())
+    
+    lazy var calendar: FSCalendar = {
+        $0.locale = Locale(identifier: "ko_KR")
+        $0.allowsMultipleSelection = true
+        $0.appearance.headerTitleColor = .clear
+        $0.appearance.headerMinimumDissolvedAlpha = 0
+        $0.appearance.subtitleOffset = CGPoint(x: 0, y: 4)
+        $0.appearance.titleTodayColor = YBColor.black.color
+        $0.appearance.weekdayTextColor = YBColor.black.color
+        $0.appearance.weekdayFont = YBFont.title1.font
+        $0.appearance.titleFont = YBFont.title1.font
+        $0.calendarWeekdayView.weekdayLabels[0].textColor = YBColor.mainRed.color
+        $0.calendarWeekdayView.backgroundColor = .clear
+        $0.placeholderType = .none
+        $0.register(YBCalendarCell.self, forCellReuseIdentifier: YBCalendarCell.identifier)
+        return $0
+    }(FSCalendar())
+    
+    private var dateformatter: DateFormatter = {
+        $0.dateFormat = "yyyy년 MM월"
+        $0.locale = Locale(identifier: "ko_KR")
+        return $0
+    }(DateFormatter())
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setView()
+        addViews()
+        setLayouts()
+        bind()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("Not implemented xib init")
+    }
+    
+    // MARK: - Set UI
+    private func setView() {
+        backgroundColor = YBColor.gray1.color
+    }
+    
+    private func addViews() {
+        [
+            dividerView,
+            prevMonthButton,
+            monthHeaderLabel,
+            nextMonthButton,
+            calendar
+        ].forEach {
+            addSubview($0)
+        }
+    }
+    
+    private func setLayouts() {
+        dividerView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+        }
+        monthHeaderLabel.snp.makeConstraints { make in
+            make.top.equalTo(dividerView.snp.bottom).inset(-26)
+            make.centerX.equalToSuperview()
+        }
+        prevMonthButton.snp.makeConstraints { make in
+            make.centerY.equalTo(monthHeaderLabel.snp.centerY)
+            make.leading.equalToSuperview().inset(22)
+            make.size.equalTo(30)
+        }
+        nextMonthButton.snp.makeConstraints { make in
+            make.centerY.equalTo(monthHeaderLabel.snp.centerY)
+            make.trailing.equalToSuperview().inset(22)
+            make.size.equalTo(30)
+        }
+        calendar.snp.makeConstraints { make in
+            make.top.equalTo(monthHeaderLabel.snp.bottom).inset(-30)
+            make.leading.trailing.equalToSuperview().inset(22)
+            make.bottom.equalToSuperview().inset(40)
+        }
+    }
+    
+    private func bind() {
+        prevMonthButton.rx.tap
+            .bind { [weak self] _ in
+                guard let self = self else { return }
+                let currentMonth = self.calendar.currentPage
+                guard let previousMonth = Calendar.current.date(byAdding: .month, value: -1, to: currentMonth) else { return }
+                self.calendar.setCurrentPage(previousMonth, animated: true)
+            }.disposed(by: disposeBag)
+        
+        nextMonthButton.rx.tap
+            .bind { [weak self] _ in
+                guard let self = self else { return }
+                let currentMonth = self.calendar.currentPage
+                guard let nextMonth = Calendar.current.date(byAdding: .month, value: 1, to: currentMonth) else { return }
+                self.calendar.setCurrentPage(nextMonth, animated: true)
+            }.disposed(by: disposeBag)
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/SubViews/CalendarView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/SubViews/CalendarView.swift
@@ -19,7 +19,7 @@ class CalendarView: UIView {
     private let dividerView = YBDivider(height: 0.6, color: .gray3)
     lazy var monthHeaderLabel = YBLabel(text: dateformatter.string(from: Date()), font: .body1, textColor: .black)
     
-    lazy var prevMonthButton: UIButton = {
+    lazy var previousMonthButton: UIButton = {
         let image = UIImage(systemName:"chevron.backward")?.withTintColor(YBColor.black.color, renderingMode: .alwaysOriginal)
         $0.setImage(image, for: .normal)
         return $0
@@ -76,7 +76,7 @@ class CalendarView: UIView {
     private func addViews() {
         [
             dividerView,
-            prevMonthButton,
+            previousMonthButton,
             monthHeaderLabel,
             nextMonthButton,
             calendar
@@ -93,7 +93,7 @@ class CalendarView: UIView {
             make.top.equalTo(dividerView.snp.bottom).inset(-26)
             make.centerX.equalToSuperview()
         }
-        prevMonthButton.snp.makeConstraints { make in
+        previousMonthButton.snp.makeConstraints { make in
             make.centerY.equalTo(monthHeaderLabel.snp.centerY)
             make.leading.equalToSuperview().inset(22)
             make.size.equalTo(30)
@@ -111,7 +111,7 @@ class CalendarView: UIView {
     }
     
     private func bind() {
-        prevMonthButton.rx.tap
+        previousMonthButton.rx.tap
             .bind { [weak self] _ in
                 guard let self = self else { return }
                 let currentMonth = self.calendar.currentPage

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/SubViews/YBCalendarCell.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/SubViews/YBCalendarCell.swift
@@ -1,0 +1,141 @@
+//
+//  YBCalendarCell.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+import SnapKit
+import FSCalendar
+
+enum SelectionType {
+    case none
+    case single
+    case leftBorder
+    case middle
+    case rightBorder
+}
+
+class YBCalendarCell: FSCalendarCell {
+    static let identifier = "YBCalendarCell"
+    
+    weak var circleImageView: UIImageView?
+    weak var selectionLayer: CAShapeLayer?
+    weak var roundedLayer: CAShapeLayer?
+
+    var selectionType: SelectionType = .none {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+
+    required init!(coder aDecoder: NSCoder!) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    private func commonInit() {
+        let selectionLayer = CAShapeLayer()
+        selectionLayer.fillColor = YBColor.brightGreen.color.cgColor
+        selectionLayer.actions = ["hidden": NSNull()]
+        self.contentView.layer.insertSublayer(selectionLayer, below: self.titleLabel?.layer)
+        self.selectionLayer = selectionLayer
+
+        let roundedLayer = CAShapeLayer()
+        roundedLayer.fillColor = YBColor.mainGreen.color.cgColor
+        roundedLayer.actions = ["hidden": NSNull()]
+        self.contentView.layer.insertSublayer(roundedLayer, below: self.titleLabel?.layer)
+        self.roundedLayer = roundedLayer
+
+        self.shapeLayer.isHidden = true
+        let view = UIView(frame: self.bounds)
+        self.backgroundView = view
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        self.selectionLayer?.frame = self.contentView.bounds
+        self.roundedLayer?.frame = self.contentView.bounds
+
+        let contentHeight = self.contentView.frame.height
+        let contentWidth = self.contentView.frame.width
+
+        let selectionLayerBounds = selectionLayer?.bounds ?? .zero
+        let selectionLayerWidth = selectionLayer?.bounds.width ?? .zero
+        let roundedLayerHeight = roundedLayer?.frame.height ?? .zero
+        let roundedLayerWidth = roundedLayer?.frame.width ?? .zero
+        
+        titleLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+
+        switch selectionType {
+        case .middle:
+            self.selectionLayer?.isHidden = false
+            self.roundedLayer?.isHidden = true
+
+            let selectionRect = selectionLayerBounds
+                .insetBy(dx: 0.0, dy: 4.0)
+            self.selectionLayer?.path = UIBezierPath(rect: selectionRect).cgPath
+
+        case .leftBorder:
+            self.selectionLayer?.isHidden = false
+            self.roundedLayer?.isHidden = false
+
+            let selectionRect = selectionLayerBounds
+                .insetBy(dx: selectionLayerWidth / 4, dy: 4)
+                .offsetBy(dx: selectionLayerWidth / 4, dy: 0.0)
+            self.selectionLayer?.path = UIBezierPath(rect: selectionRect).cgPath
+
+            let diameter: CGFloat = min(roundedLayerHeight, roundedLayerWidth)
+            let rect = CGRect(x: contentWidth / 2 - diameter / 2,
+                              y: contentHeight / 2 - diameter / 2,
+                              width: diameter,
+                              height: diameter)
+                .insetBy(dx: 2.5, dy: 2.5)
+            self.roundedLayer?.path = UIBezierPath(ovalIn: rect).cgPath
+
+        case .rightBorder:
+            self.selectionLayer?.isHidden = false
+            self.roundedLayer?.isHidden = false
+
+            let selectionRect = selectionLayerBounds
+                .insetBy(dx: selectionLayerWidth / 4, dy: 4)
+                .offsetBy(dx: -selectionLayerWidth / 4, dy: 0.0)
+            self.selectionLayer?.path = UIBezierPath(rect: selectionRect).cgPath
+
+            let diameter: CGFloat = min(roundedLayerHeight, roundedLayerWidth)
+            let rect = CGRect(x: contentWidth / 2 - diameter / 2,
+                              y: contentHeight / 2 - diameter / 2,
+                              width: diameter,
+                              height: diameter)
+                .insetBy(dx: 2.5, dy: 2.5)
+            self.roundedLayer?.path = UIBezierPath(ovalIn: rect).cgPath
+
+        case .single:
+            self.selectionLayer?.isHidden = true
+            self.roundedLayer?.isHidden = false
+
+            let diameter: CGFloat = min(roundedLayerHeight, roundedLayerWidth)
+            let rect = CGRect(x: contentWidth / 2 - diameter / 2,
+                              y: contentHeight / 2 - diameter / 2,
+                              width: diameter,
+                              height: diameter)
+                .insetBy(dx: 2.5, dy: 2.5)
+            self.roundedLayer?.path = UIBezierPath(ovalIn: rect).cgPath
+
+        case .none:
+            self.selectionLayer?.isHidden = true
+            self.roundedLayer?.isHidden = true
+        }
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Country/CountryReactor.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Country/CountryReactor.swift
@@ -18,7 +18,6 @@ public final class CountryReactor: Reactor {
         case typeButtonTapped(title: String)
         case checkedButtonTapped(country: Country)
         case deletedCountry(country: Country)
-        case nextButtonTapped
     }
     
     public enum Mutation {
@@ -26,7 +25,6 @@ public final class CountryReactor: Reactor {
         case typeButtonTapped(title: String)
         case checkedButtonTapped(country: Country)
         case deletedCountry(country: Country)
-        case nextButtonTapped
     }
     
     public struct State {
@@ -51,8 +49,6 @@ public final class CountryReactor: Reactor {
             return .just(Mutation.checkedButtonTapped(country: country))
         case .deletedCountry(country: let country):
             return .just(Mutation.deletedCountry(country: country))
-        case .nextButtonTapped:
-            return .just(Mutation.nextButtonTapped)
         }
     }
     
@@ -122,9 +118,6 @@ public final class CountryReactor: Reactor {
             if let selectedCountryIndex = newState.selectedCountries.firstIndex(where: { $0.name == country.name }) {
                 newState.selectedCountries.remove(at: selectedCountryIndex)
             }
-        case .nextButtonTapped:
-            print("next 찍힘")
-            break
         }
         return newState
     }

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Country/CountryViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Country/CountryViewController.swift
@@ -231,8 +231,9 @@ extension CountryViewController: View {
         }
         
         nextButton.rx.tap
-            .bind { _ in
-                reactor.action.onNext(Reactor.Action.nextButtonTapped)
+            .bind { [weak self] _ in
+                let calendarVC = CalendarViewController()
+                self?.navigationController?.pushViewController(calendarVC, animated: true)
             }.disposed(by: disposeBag)
     }
     

--- a/Projects/Features/TravelRegistration/Sources/Util/TravelRegistrationController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Util/TravelRegistrationController.swift
@@ -7,12 +7,14 @@
 //
 
 import UIKit
+import DesignSystem
 
 public class TravelRegistrationController: UIViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
         setView()
+        configureBar()
     }
     
     private func setView() {
@@ -28,5 +30,15 @@ public class TravelRegistrationController: UIViewController {
     
     @objc func dismissKeyboard() {
         navigationController?.view.endEditing(true)
+    }
+    
+    func configureBar() {
+        let backImage = UIImage(systemName: "chevron.backward")?.withTintColor(YBColor.gray5.color, renderingMode: .alwaysOriginal)
+        let backButton = UIBarButtonItem(image: backImage, style: .plain, target: self, action: #selector(backButtonTapped))
+        self.navigationItem.leftBarButtonItem = backButton
+    }
+    
+    @objc func backButtonTapped() {
+        self.navigationController?.popViewController(animated: true)
     }
 }


### PR DESCRIPTION
## 이슈번호
[YB-78]

## 수정 사항
- DesignSystem에 YBPaddingLabel 추가하였습니다.
- Padding enum에 calendarDate case 추가해서 캘린더 날짜 Label에 적용했습니다.
- 2차 뎁캠 때 말씀드렸던 calendar Delegate를 reactor로 바인딩 해결했습니다.
- calendar Cell 글자 원의 중앙에 맞게 정렬 해두었습니다.


## 화면 (Optional)
| 선택x | 시작날짜 선택 | 선택 완료 |
| --- | --- | --- | 
|<img width="350" alt="스크린샷 2024-01-07 오후 12 43 17" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/3cde1ec3-8892-441e-b3df-539862d5b1f5">| <img width="350" alt="스크린샷 2024-01-07 오후 12 43 44" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/e52e9d78-446a-4c31-9e1c-6eb741c54353">| <img width="350" alt="스크린샷 2024-01-07 오후 12 43 49" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/cafbcc20-b391-4a9b-a004-92a21a97a4df">|

<img width="300" alt="스크린샷 2024-01-07 오후 12 43 17" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/fded7e4c-bef7-44e1-a318-92fbda480f31">



## target module
- TravelRegistration

## 참고사항
- 네비게이션 백 버튼이랑 캘린더 좌우 버튼이 기본 fssymbol에 있는 이미지를 그대로 썼고 피그마 사이즈에 맞게 적용했는데 약간 작은 느낌이네여..ㅎㅎ
- PR이 너무 길어 제성함다.. 

[YB-78]: https://yeobee.atlassian.net/browse/YB-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ