### PR TITLE
[YB-84] 개인 지출 등록 화면의 금액 텍스트 입력 카테고리 영역을 구현합니다

### DIFF
--- a/Projects/DesignSystem/Sources/Asset/YBFont.swift
+++ b/Projects/DesignSystem/Sources/Asset/YBFont.swift
@@ -62,7 +62,7 @@ extension YBFont {
         case .body1: return .system(size: 16, weight: .bold)
         case .body2: return .system(size: 15, weight: .bold)
         case .body3: return .system(size: 14, weight: .semibold)
-        case .body4: return .system(size: 20, weight: .medium)
+        case .body4: return .system(size: 13, weight: .medium)
         }
     }
 }

--- a/Projects/DesignSystem/Sources/Label/YBDecimalLabel.swift
+++ b/Projects/DesignSystem/Sources/Label/YBDecimalLabel.swift
@@ -50,7 +50,7 @@ public extension YBDecimalLabel {
     }
 }
 
-private extension Formatter {
+public extension Formatter {
     static let withSeparator: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.groupingSeparator = ","
@@ -59,7 +59,7 @@ private extension Formatter {
     }()
 }
 
-extension Numeric {
+public extension Numeric {
     var formattedWithSeparator: String {
         return Formatter.withSeparator.string(for: self) ?? ""
     }

--- a/Projects/Features/ExpenditureEdit/DemoApp/Sources/ExpenditureEditAppDelegate.swift
+++ b/Projects/Features/ExpenditureEdit/DemoApp/Sources/ExpenditureEditAppDelegate.swift
@@ -1,0 +1,21 @@
+//
+//  ExpenditureEditAppDelegate.swift
+//  ExpenditureEditDemoApp
+//
+//  Created by Hoyoung Lee on 
+//
+
+import UIKit
+import ExpenditureEdit
+
+@main
+class ExpenditureEditAppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    self.window = UIWindow(frame: UIScreen.main.bounds)
+    self.window?.rootViewController = ExpenditureEditViewController()
+    self.window?.makeKeyAndVisible()
+    return true
+  }
+}
+

--- a/Projects/Features/ExpenditureEdit/Project.swift
+++ b/Projects/Features/ExpenditureEdit/Project.swift
@@ -1,0 +1,75 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project(
+    name: "ExpenditureEdit",
+    organizationName: "YeoBee.com",
+    options: .options(
+        automaticSchemesOptions: .disabled
+    ),
+    packages: [
+    ],
+    settings: .settings(configurations: [
+        .debug(name: .debug),
+        .release(name: .release),
+    ]),
+    targets: [
+        Project.target(
+            name: "ExpenditureEdit",
+            product: .framework,
+            sources: .sources,
+            dependencies: [
+                .designSystem,
+                .RxSwift,
+                .RxCocoa,
+                .reactorKit,
+                .composableArchitecture
+            ]
+        ),
+        Project.target(
+            name: "ExpenditureEditDemo",
+            product: .app,
+            sources: .demoSources,
+            dependencies: [
+                .target(name: "ExpenditureEdit")
+            ]
+        ),
+        Project.target(
+            name: "ExpenditureEditTests",
+            product: .unitTests,
+            sources: .tests,
+            dependencies: [
+                .target(name: "ExpenditureEdit")
+            ]
+        )
+    ],
+    schemes: [
+        Scheme(
+            name: "ExpenditureEditDemo",
+            shared: true,
+            buildAction: BuildAction(
+                targets: ["ExpenditureEditDemo"]
+            ),
+            testAction: .targets(["ExpenditureEditTests"]),
+            runAction: .runAction(configuration: .debug),
+            archiveAction: .archiveAction(configuration: .debug),
+            profileAction: .profileAction(configuration: .debug),
+            analyzeAction: .analyzeAction(configuration: .debug)
+        ),
+        Scheme(
+            name: "ExpenditureEdit",
+            shared: true,
+            buildAction: BuildAction(
+                targets: ["ExpenditureEdit"]
+            ),
+            testAction: .targets(["ExpenditureEditTests"]),
+            runAction: .runAction(configuration: .release),
+            archiveAction: .archiveAction(configuration: .release),
+            profileAction: .profileAction(configuration: .release),
+            analyzeAction: .analyzeAction(configuration: .release)
+        )
+    ],
+    fileHeaderTemplate: nil,
+    additionalFiles: [],
+    resourceSynthesizers: []
+)

--- a/Projects/Features/ExpenditureEdit/Project.swift
+++ b/Projects/Features/ExpenditureEdit/Project.swift
@@ -31,7 +31,7 @@ let project = Project(
             product: .app,
             sources: .demoSources,
             dependencies: [
-                .target(name: "ExpenditureEdit")
+                .expenditureEdit
             ]
         ),
         Project.target(

--- a/Projects/Features/ExpenditureEdit/Sources/Calculation/CalculationReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/Calculation/CalculationReducer.swift
@@ -1,0 +1,25 @@
+//
+//  CalculationReducer.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import Combine
+import ComposableArchitecture
+
+public struct CalculationReducer: Reducer {
+    public struct State: Equatable {
+    }
+
+    public enum Action {
+    }
+
+    public var body: some ReducerOf<CalculationReducer> {
+        Reduce { _, action in
+            switch action {
+                default: return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/Calculation/CalculationView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/Calculation/CalculationView.swift
@@ -1,0 +1,20 @@
+//
+//  CalculationView.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import SwiftUI
+import ComposableArchitecture
+
+struct CalculationView: View {
+    typealias State = CalculationReducer.State
+    typealias Action = CalculationReducer.Action
+
+    let store: StoreOf<CalculationReducer>
+
+    var body: some View {
+        Text("Hello world!")
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/Common/KeyboardAdaptive.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/Common/KeyboardAdaptive.swift
@@ -1,0 +1,55 @@
+//
+//  KeyboardAdaptive.swift
+//  ExpenditureEdit
+//
+//  Created by Hoyoung Lee on 1/7/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    public func keyboardAdaptive() -> some View {
+       self.modifier(KeyboardAdaptive())
+     }
+}
+
+public struct KeyboardAdaptive: ViewModifier {
+  public func body(content: Content) -> some View {
+    content
+      .onAppear(perform: UIApplication.shared.addTapGestureRecognizer)
+      .onDisappear(perform: UIApplication.shared.removeTapGestureRecognizer)
+  }
+}
+
+
+extension UIApplication {
+  func addTapGestureRecognizer() {
+    guard let window = windows.first else { return }
+    let tapGesture = UITapGestureRecognizer(target: window, action: #selector(UIView.endEditing))
+    tapGesture.cancelsTouchesInView = false
+    tapGesture.delegate = self
+    tapGesture.name = "KeyboardDismissGesture"
+    window.addGestureRecognizer(tapGesture)
+  }
+
+  func removeTapGestureRecognizer() {
+    guard let window = windows.first else { return }
+
+    window.gestureRecognizers?.forEach { gr in
+      if gr.name == "KeyboardDismissGesture" {
+        window.removeGestureRecognizer(gr)
+      }
+
+    }
+  }
+}
+
+extension UIApplication: UIGestureRecognizerDelegate {
+  public func gestureRecognizer(
+    _ gestureRecognizer: UIGestureRecognizer,
+    shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+  ) -> Bool {
+    return false
+  }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemReducer.swift
@@ -1,0 +1,35 @@
+//
+//  ExpenditureCategoryItemReducer.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import Combine
+import ComposableArchitecture
+
+enum Category: CaseIterable {
+    case activity, air, eating, etc, shopping, stay, transition, travel
+}
+
+public struct ExpenditureCategoryItemReducer: Reducer {
+    public struct State: Equatable, Identifiable {
+        public var id: String { return category.text }
+        var category: Category
+        init(category: Category) {
+            self.category = category
+        }
+    }
+
+    public enum Action: Equatable {
+        case tappedCategory
+    }
+
+    public var body: some ReducerOf<ExpenditureCategoryItemReducer> {
+        Reduce { _, action in
+            switch action {
+                default: return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemReducer.swift
@@ -9,7 +9,7 @@ import Combine
 import ComposableArchitecture
 
 enum Category: CaseIterable {
-    case activity, air, eating, etc, shopping, stay, transition, travel
+    case transition, eating, stay, travel, activity, shopping, air, etc
 }
 
 public struct ExpenditureCategoryItemReducer: Reducer {

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemReducer.swift
@@ -16,8 +16,10 @@ public struct ExpenditureCategoryItemReducer: Reducer {
     public struct State: Equatable, Identifiable {
         public var id: String { return category.text }
         var category: Category
-        init(category: Category) {
+        var isSelected: Bool
+        init(category: Category, isSelected: Bool = false) {
             self.category = category
+            self.isSelected = isSelected
         }
     }
 

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemView.swift
@@ -1,0 +1,68 @@
+//
+//  ExpenditureCategoryItemView.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import SwiftUI
+import ComposableArchitecture
+import DesignSystem
+
+struct ExpenditureCategoryItemView: View {
+    typealias State = ExpenditureCategoryItemReducer.State
+    typealias Action = ExpenditureCategoryItemReducer.Action
+
+    let store: StoreOf<ExpenditureCategoryItemReducer>
+
+    var body: some View {
+        containerView
+    }
+}
+
+extension ExpenditureCategoryItemView {
+    var containerView: some View {
+        WithViewStore(store, observe: \.category) { viewStore in
+            Button(action: {
+                viewStore.send(.tappedCategory)
+            }, label: {
+                VStack(alignment: .center) {
+                    viewStore.state.image
+                        .resizable()
+                        .frame(width: 41, height: 41)
+                    Text(viewStore.state.text)
+                        .foregroundColor(.ybColor(.gray4))
+                        .font(.ybfont(.body2))
+                }
+            })
+        }
+    }
+}
+
+extension Category {
+    var text: String {
+        switch self {
+        case .activity: return "액티비티"
+        case .air: return "항공"
+        case .eating: return "식비"
+        case .shopping: return "쇼핑"
+        case .stay: return "숙박"
+        case .transition: return "교통"
+        case .travel: return "관광"
+        case .etc: return "기타"
+        }
+    }
+
+    var image: Image {
+        switch self {
+        case .activity: return DesignSystemAsset.Icons.activity.swiftUIImage
+        case .air: return DesignSystemAsset.Icons.air.swiftUIImage
+        case .eating: return DesignSystemAsset.Icons.eating.swiftUIImage
+        case .etc: return DesignSystemAsset.Icons.etc.swiftUIImage
+        case .shopping: return DesignSystemAsset.Icons.shopping.swiftUIImage
+        case .stay: return DesignSystemAsset.Icons.stay.swiftUIImage
+        case .transition: return DesignSystemAsset.Icons.transition.swiftUIImage
+        case .travel: return DesignSystemAsset.Icons.travel.swiftUIImage
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryItemView.swift
@@ -21,18 +21,39 @@ struct ExpenditureCategoryItemView: View {
 }
 
 extension ExpenditureCategoryItemView {
+
+    struct CategoryViewState: Equatable {
+        let category: Category
+        let isSelected: Bool
+
+        init(state: State) {
+            self.category = state.category
+            self.isSelected = state.isSelected
+        }
+    }
+
     var containerView: some View {
-        WithViewStore(store, observe: \.category) { viewStore in
+        WithViewStore(store, observe: CategoryViewState.init) { viewStore in
             Button(action: {
                 viewStore.send(.tappedCategory)
             }, label: {
                 VStack(alignment: .center) {
-                    viewStore.state.image
-                        .resizable()
-                        .frame(width: 41, height: 41)
-                    Text(viewStore.state.text)
-                        .foregroundColor(.ybColor(.gray4))
-                        .font(.ybfont(.body2))
+                    if viewStore.isSelected {
+                        viewStore.category.image
+                            .resizable()
+                            .frame(width: 41, height: 41)
+                        Text(viewStore.category.text)
+                            .foregroundColor(.ybColor(.black))
+                            .font(.ybfont(.body2))
+                    } else {
+                        viewStore.category.image
+                            .renderingMode(.template)
+                            .foregroundColor(YBColor.gray2.swiftUIColor)
+                            .frame(width: 41, height: 41)
+                        Text(viewStore.category.text)
+                            .foregroundColor(.ybColor(.gray4))
+                            .font(.ybfont(.body2))
+                    }
                 }
             })
         }

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
@@ -25,6 +25,7 @@ public struct ExpenditureCategoryReducer: Reducer {
         case category(ExpenditureCategoryItemReducer.State.ID, ExpenditureCategoryItemReducer.Action)
         case setTextField(String)
         case binding(BindingAction<State>)
+        case setFocusState(Bool)
     }
 
     public var body: some ReducerOf<ExpenditureCategoryReducer> {

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
@@ -1,0 +1,36 @@
+//
+//  ExpenditureCategoryReducer.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import Combine
+import ComposableArchitecture
+
+public struct ExpenditureCategoryReducer: Reducer {
+    public struct State: Equatable {
+        var categoryItems: IdentifiedArrayOf<ExpenditureCategoryItemReducer.State> = []
+        
+        init() {
+            Category.allCases.forEach {
+                self.categoryItems.updateOrAppend(ExpenditureCategoryItemReducer.State(category: $0))
+            }
+        }
+    }
+
+    public enum Action: Equatable {
+        case category(ExpenditureCategoryItemReducer.State.ID, ExpenditureCategoryItemReducer.Action)
+    }
+
+    public var body: some ReducerOf<ExpenditureCategoryReducer> {
+        Reduce { _, action in
+            switch action {
+                default: return .none
+            }
+        }
+        .forEach(\.categoryItems, action: /Action.category) {
+            ExpenditureCategoryItemReducer()
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
@@ -12,6 +12,7 @@ public struct ExpenditureCategoryReducer: Reducer {
     public struct State: Equatable {
         var categoryItems: IdentifiedArrayOf<ExpenditureCategoryItemReducer.State> = []
         @BindingState var text: String = ""
+        var isInvaildText: Bool = false
 
         init() {
             Category.allCases.forEach {
@@ -27,11 +28,17 @@ public struct ExpenditureCategoryReducer: Reducer {
     }
 
     public var body: some ReducerOf<ExpenditureCategoryReducer> {
+        BindingReducer()
         Reduce { state, action in
             switch action {
             case let .category(id, .tappedCategory):
                 state.text = state.categoryItems[id: id]?.category.text ?? ""
                 return .none
+                
+            case .binding(\.$text):
+                state.isInvaildText = vaildText(state.text)
+                return .none
+
             default:
                 return .none
             }
@@ -39,5 +46,9 @@ public struct ExpenditureCategoryReducer: Reducer {
         .forEach(\.categoryItems, action: /Action.category) {
             ExpenditureCategoryItemReducer()
         }
+    }
+
+    func vaildText(_ text: String) -> Bool {
+        return text.count > 10
     }
 }

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
@@ -11,7 +11,8 @@ import ComposableArchitecture
 public struct ExpenditureCategoryReducer: Reducer {
     public struct State: Equatable {
         var categoryItems: IdentifiedArrayOf<ExpenditureCategoryItemReducer.State> = []
-        
+        @BindingState var text: String = ""
+
         init() {
             Category.allCases.forEach {
                 self.categoryItems.updateOrAppend(ExpenditureCategoryItemReducer.State(category: $0))
@@ -19,14 +20,20 @@ public struct ExpenditureCategoryReducer: Reducer {
         }
     }
 
-    public enum Action: Equatable {
+    public enum Action: Equatable, BindableAction {
         case category(ExpenditureCategoryItemReducer.State.ID, ExpenditureCategoryItemReducer.Action)
+        case setTextField(String)
+        case binding(BindingAction<State>)
     }
 
     public var body: some ReducerOf<ExpenditureCategoryReducer> {
-        Reduce { _, action in
+        Reduce { state, action in
             switch action {
-                default: return .none
+            case let .category(id, .tappedCategory):
+                state.text = state.categoryItems[id: id]?.category.text ?? ""
+                return .none
+            default:
+                return .none
             }
         }
         .forEach(\.categoryItems, action: /Action.category) {

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryReducer.swift
@@ -33,7 +33,11 @@ public struct ExpenditureCategoryReducer: Reducer {
         Reduce { state, action in
             switch action {
             case let .category(id, .tappedCategory):
-                state.text = state.categoryItems[id: id]?.category.text ?? ""
+                let selectedCategory = state.categoryItems[id: id]?.category
+                Category.allCases.forEach { category in
+                    state.categoryItems.updateOrAppend(.init(category: category, isSelected: category == selectedCategory))
+                }
+                state.text = selectedCategory?.text ?? ""
                 return .none
                 
             case .binding(\.$text):

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryView.swift
@@ -1,0 +1,56 @@
+//
+//  ExpenditureCategoryView.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import SwiftUI
+import ComposableArchitecture
+
+struct ExpenditureCategoryView: View {
+    typealias State = ExpenditureCategoryReducer.State
+    typealias Action = ExpenditureCategoryReducer.Action
+
+    let store: StoreOf<ExpenditureCategoryReducer>
+
+    var body: some View {
+        containerView
+    }
+}
+
+extension ExpenditureCategoryView {
+    var containerView: some View {
+
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 0) {
+                Text("카테고리")
+                    .foregroundColor(.ybColor(.black))
+                    .font(.ybfont(.title1))
+                Text("*")
+                    .foregroundColor(.ybColor(.mainGreen))
+                    .font(.ybfont(.body3))
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 20) {
+                    ForEachStore(
+                        store.scope(
+                            state: \.categoryItems,
+                            action: ExpenditureCategoryReducer.Action.category
+                        )
+                    ) { store in
+                        ExpenditureCategoryItemView(store: store)
+                    }
+                }
+            }
+            HStack(alignment: .center, spacing: 10) {
+                Text("지출항목")
+                    .foregroundColor(.ybColor(.black))
+                    .font(.ybfont(.title1))
+                Spacer()
+                ExpenditureTextFieldView(text: .constant("123"), placeholder: "내용을 입력해주세요.")
+            }
+        }
+        .padding(.horizontal, 24)
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
+import DesignSystem
 
 struct ExpenditureCategoryView: View {
     typealias State = ExpenditureCategoryReducer.State
@@ -47,12 +48,20 @@ extension ExpenditureCategoryView {
             }
             .padding(.leading, 24)
             WithViewStore(store, observe: { $0 }) { viewStore in
-                HStack(alignment: .center, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
                     Text("지출항목")
                         .foregroundColor(.ybColor(.black))
                         .font(.ybfont(.title1))
+                        .padding(.top, 12)
                     Spacer()
-                    ExpenditureTextFieldView(text: viewStore.$text, placeholder: "내용을 입력해주세요.")
+                    VStack(alignment: .leading) {
+                        ExpenditureTextFieldView(text: viewStore.$text, placeholder: "내용을 입력해주세요.")
+                        if viewStore.isInvaildText {
+                            Text("한글, 영어 포함 10자 이내로 입력해주세요.")
+                                .foregroundColor(.ybColor(.mainRed))
+                                .font(.ybfont(.body4))
+                        }
+                    }
                 }
                 .padding(.horizontal, 24)
             }

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryView.swift
@@ -20,8 +20,9 @@ struct ExpenditureCategoryView: View {
 }
 
 extension ExpenditureCategoryView {
-    var containerView: some View {
 
+    @MainActor
+    var containerView: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 0) {
                 Text("카테고리")
@@ -31,6 +32,7 @@ extension ExpenditureCategoryView {
                     .foregroundColor(.ybColor(.mainGreen))
                     .font(.ybfont(.body3))
             }
+            .padding(.leading, 24)
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEachStore(
@@ -43,14 +45,18 @@ extension ExpenditureCategoryView {
                     }
                 }
             }
-            HStack(alignment: .center, spacing: 10) {
-                Text("지출항목")
-                    .foregroundColor(.ybColor(.black))
-                    .font(.ybfont(.title1))
-                Spacer()
-                ExpenditureTextFieldView(text: .constant("123"), placeholder: "내용을 입력해주세요.")
+            .padding(.leading, 24)
+            WithViewStore(store, observe: { $0 }) { viewStore in
+                HStack(alignment: .center, spacing: 10) {
+                    Text("지출항목")
+                        .foregroundColor(.ybColor(.black))
+                        .font(.ybfont(.title1))
+                    Spacer()
+                    ExpenditureTextFieldView(text: viewStore.$text, placeholder: "내용을 입력해주세요.")
+                }
+                .padding(.horizontal, 24)
             }
         }
-        .padding(.horizontal, 24)
+
     }
 }

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureCategoryView.swift
@@ -15,6 +15,8 @@ struct ExpenditureCategoryView: View {
 
     let store: StoreOf<ExpenditureCategoryReducer>
 
+    @FocusState var focus: Bool
+
     var body: some View {
         containerView
     }
@@ -55,13 +57,16 @@ extension ExpenditureCategoryView {
                         .padding(.top, 12)
                     Spacer()
                     VStack(alignment: .leading) {
-                        ExpenditureTextFieldView(text: viewStore.$text, placeholder: "내용을 입력해주세요.")
+                        ExpenditureTextFieldView(text: viewStore.$text, focused: $focus, placeholder: "내용을 입력해주세요.")
                         if viewStore.isInvaildText {
                             Text("한글, 영어 포함 10자 이내로 입력해주세요.")
                                 .foregroundColor(.ybColor(.mainRed))
                                 .font(.ybfont(.body4))
                         }
                     }
+                    .onChange(of: focus, perform: { value in
+                        viewStore.send(.setFocusState(value))
+                    })
                 }
                 .padding(.horizontal, 24)
             }

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureTextFieldView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureTextFieldView.swift
@@ -1,0 +1,49 @@
+//
+//  ExpenditureTextFieldView.swift
+//  ExpenditureEdit
+//
+//  Created by Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct ExpenditureTextFieldView: View {
+    @FocusState private var isFocused: Bool
+    @Binding var text: String
+    private let placeholder: String
+
+    public init(
+        text: Binding<String>,
+        placeholder: String
+    ) {
+        self._text = text
+        self.placeholder = placeholder
+    }
+
+    var body: some View {
+        VStack {
+            TextField("", text: $text)
+                .focused($isFocused)
+                .foregroundColor(.ybColor(.black))
+                .font(.ybfont(.body1))
+                .overlay(alignment: .leading) {
+                    placeholderView
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 13)
+        }
+        .background(YBColor.white.swiftUIColor)
+        .cornerRadius(10)
+    }
+}
+
+extension ExpenditureTextFieldView  {
+    private var placeholderView: some View {
+        Text(placeholder)
+            .foregroundColor(.ybColor(.gray4))
+            .font(.ybfont(.body1))
+            .opacity(text.isEmpty ? 1 : 0)
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureTextFieldView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureCategory/ExpenditureTextFieldView.swift
@@ -10,22 +10,24 @@ import SwiftUI
 import DesignSystem
 
 struct ExpenditureTextFieldView: View {
-    @FocusState private var isFocused: Bool
+    var focus: FocusState<Bool>.Binding
     @Binding var text: String
     private let placeholder: String
 
     public init(
         text: Binding<String>,
+        focused: FocusState<Bool>.Binding,
         placeholder: String
     ) {
         self._text = text
+        self.focus = focused
         self.placeholder = placeholder
     }
 
     var body: some View {
         VStack {
             TextField("", text: $text)
-                .focused($isFocused)
+                .focused(focus)
                 .foregroundColor(.ybColor(.black))
                 .font(.ybfont(.body1))
                 .overlay(alignment: .leading) {
@@ -36,6 +38,7 @@ struct ExpenditureTextFieldView: View {
         }
         .background(YBColor.white.swiftUIColor)
         .cornerRadius(10)
+        .id("expenditureCategoryType")
     }
 }
 

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditReducer.swift
@@ -13,6 +13,9 @@ public struct ExpendpenditureEditReducer: Reducer {
         var expenditureInput = ExpenditureInputReducer.State()
         var expenditurePayment = ExpenditurePaymentReducer.State()
         var expenditureCategory = ExpenditureCategoryReducer.State()
+
+        var isFocused: Bool = false
+        var scrollItem: String = ""
     }
 
     public enum Action: Equatable {
@@ -22,8 +25,12 @@ public struct ExpendpenditureEditReducer: Reducer {
     }
 
     public var body: some ReducerOf<ExpendpenditureEditReducer> {
-        Reduce { _, action in
+        Reduce { state, action in
             switch action {
+            case let .expenditureCategory(.setFocusState(isFocused)):
+                state.isFocused = isFocused
+                state.scrollItem = "expenditureCategoryType"
+                return .none
                 default: return .none
             }
         }

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditReducer.swift
@@ -1,0 +1,43 @@
+//
+//  ExpendpenditureEditReducer.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import Combine
+import ComposableArchitecture
+
+public struct ExpendpenditureEditReducer: Reducer {
+    public struct State: Equatable {
+        var expenditureInput = ExpenditureInputReducer.State()
+        var expenditurePayment = ExpenditurePaymentReducer.State()
+        var expenditureCategory = ExpenditureCategoryReducer.State()
+    }
+
+    public enum Action: Equatable {
+        case expenditureInput(ExpenditureInputReducer.Action)
+        case expenditurePayment(ExpenditurePaymentReducer.Action)
+        case expenditureCategory(ExpenditureCategoryReducer.Action)
+    }
+
+    public var body: some ReducerOf<ExpendpenditureEditReducer> {
+        Reduce { _, action in
+            switch action {
+                default: return .none
+            }
+        }
+
+        Scope(state: \.expenditureInput, action: /Action.expenditureInput) {
+            ExpenditureInputReducer()
+        }
+
+        Scope(state: \.expenditurePayment, action: /Action.expenditurePayment) {
+            ExpenditurePaymentReducer()
+        }
+
+        Scope(state: \.expenditureCategory, action: /Action.expenditureCategory) {
+            ExpenditureCategoryReducer()
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditView.swift
@@ -16,13 +16,41 @@ struct ExpendpenditureEditView: View {
     let store: StoreOf<ExpendpenditureEditReducer>
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack {
-                containerView
+        ZStack(alignment: .bottom) {
+                ScrollViewReader { reader in
+                    WithViewStore(store, observe: \.isFocused) { viewstore in
+                    ScrollView(showsIndicators: false) {
+                        containerView
+                        .padding(.top, 10)
+                    }
+                    .ignoresSafeArea(.keyboard)
+                    .onChange(of: viewstore.state, perform: { newValue in
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
+                            withAnimation {
+                                reader.scrollTo("expenditureCategoryType", anchor: .center)
+                            }
+                        }
+                    })
+                }
             }
-            .padding(.top, 10)
-            .keyboardAdaptive()
+            Button {
+
+            } label: {
+                Text("등록하기")
+                    .foregroundColor(.ybColor(.gray5))
+                    .font(.ybfont(.title1))
+                    .frame(height: 54)
+                    .frame(maxWidth: .infinity)
+            }
+            .background(YBColor.gray3.swiftUIColor)
+            .cornerRadius(10)
+            .padding(.horizontal, 24)
+            .padding(.top, 16)
+            .padding(.bottom, 4)
+            .background(YBColor.white.swiftUIColor)
+            .ignoresSafeArea(.keyboard)
         }
+        .keyboardAdaptive()
     }
 }
 
@@ -47,6 +75,9 @@ extension ExpendpenditureEditView {
                     action: Action.expenditureCategory
                 )
             )
+            Color.clear
+                .frame(height: 200)
+
             Spacer()
         }
         .frame(maxWidth: .infinity)

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditView.swift
@@ -1,0 +1,54 @@
+//
+//  ExpendpenditureEditView.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import SwiftUI
+import ComposableArchitecture
+import DesignSystem
+
+struct ExpendpenditureEditView: View {
+    typealias State = ExpendpenditureEditReducer.State
+    typealias Action = ExpendpenditureEditReducer.Action
+
+    let store: StoreOf<ExpendpenditureEditReducer>
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            VStack {
+                containerView
+            }
+            .padding(.top, 10)
+        }
+    }
+}
+
+extension ExpendpenditureEditView {
+    var containerView: some View {
+        VStack(spacing: 20) {
+            ExpenditureInputView(
+                store: store.scope(
+                    state: \.expenditureInput,
+                    action: Action.expenditureInput
+                )
+            )
+            ExpenditurePaymentView(
+                store: store.scope(
+                    state: \.expenditurePayment,
+                    action: Action.expenditurePayment
+                )
+            )
+            ExpenditureCategoryView(
+                store: store.scope(
+                    state: \.expenditureCategory,
+                    action: Action.expenditureCategory
+                )
+            )
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .background(YBColor.gray1.swiftUIColor)
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditView.swift
@@ -17,11 +17,11 @@ struct ExpendpenditureEditView: View {
 
     var body: some View {
         ZStack(alignment: .bottom) {
-                ScrollViewReader { reader in
-                    WithViewStore(store, observe: \.isFocused) { viewstore in
+            ScrollViewReader { reader in
+                WithViewStore(store, observe: \.isFocused) { viewstore in
                     ScrollView(showsIndicators: false) {
                         containerView
-                        .padding(.top, 10)
+                            .padding(.top, 10)
                     }
                     .ignoresSafeArea(.keyboard)
                     .onChange(of: viewstore.state, perform: { newValue in
@@ -33,6 +33,7 @@ struct ExpendpenditureEditView: View {
                     })
                 }
             }
+            .keyboardAdaptive()
             Button {
 
             } label: {
@@ -48,9 +49,9 @@ struct ExpendpenditureEditView: View {
             .padding(.top, 16)
             .padding(.bottom, 4)
             .background(YBColor.white.swiftUIColor)
+            .ignoresSafeArea()
             .ignoresSafeArea(.keyboard)
         }
-        .keyboardAdaptive()
     }
 }
 

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureEdit/ExpendpenditureEditView.swift
@@ -21,6 +21,7 @@ struct ExpendpenditureEditView: View {
                 containerView
             }
             .padding(.top, 10)
+            .keyboardAdaptive()
         }
     }
 }

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureEditViewController.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureEditViewController.swift
@@ -1,0 +1,65 @@
+//
+//  ExpenditureEditViewController.swift
+//  ExpenditureEdit
+//
+//  Created by Hoyoung Lee 
+//
+
+import UIKit
+import RxSwift
+
+import DesignSystem
+import SnapKit
+import ComposableArchitecture
+
+public final class ExpenditureEditViewController: UIViewController {
+
+    public var disposeBag: DisposeBag = DisposeBag()
+
+    // MARK: View
+
+    private let expenditureHostingController = ExpenditureHostingController(
+        rootView: ExpenditureView(
+            store: .init(
+                initialState: .init(seletedExpenditureType: .shared),
+                reducer: {
+                    ExpenditureReducer()
+                }
+            )
+        )
+    )
+
+//    // MARK: DataSources
+//
+//    private let tripDateDataSource: TripDateDataSource
+
+    public init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupViews()
+        setLayouts()
+    }
+
+    required convenience init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    func setupViews() {
+        title = "일본 여행"
+        view.backgroundColor = .ybColor(.gray1)
+    }
+
+    func setLayouts() {
+        view.addSubview(expenditureHostingController.view)
+
+        expenditureHostingController.view.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+            make.horizontalEdges.equalToSuperview()
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureEditViewController.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureEditViewController.swift
@@ -58,7 +58,7 @@ public final class ExpenditureEditViewController: UIViewController {
 
         expenditureHostingController.view.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+            make.bottom.equalTo(view.snp.bottom)
             make.horizontalEdges.equalToSuperview()
         }
     }

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/CurrencyTextFieldView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/CurrencyTextFieldView.swift
@@ -1,0 +1,43 @@
+//
+//  CurrencyTextFieldView.swift
+//  ExpenditureEdit
+//
+//  Created by Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import SwiftUI
+
+struct CurrencyTextFieldView: View {
+    @FocusState private var isFocused: Bool
+    @Binding var text: String
+    private let placeholder: String
+
+    public init(
+        text: Binding<String>,
+        placeholder: String
+    ) {
+        self._text = text
+        self.placeholder = placeholder
+    }
+
+    var body: some View {
+        TextField("", text: $text)
+            .keyboardType(.decimalPad)
+            .focused($isFocused)
+            .foregroundColor(.ybColor(.black))
+            .font(.ybfont(.header1))
+            .overlay(alignment: .leading) {
+                placeholderView
+            }
+    }
+}
+
+extension CurrencyTextFieldView  {
+    private var placeholderView: some View {
+        Text(placeholder)
+            .foregroundColor(.ybColor(.gray4))
+            .font(.ybfont(.header1))
+            .opacity(text.isEmpty ? 1 : 0)
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/ExpendpenditureInputReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/ExpendpenditureInputReducer.swift
@@ -1,0 +1,28 @@
+//
+//  ExpendpenditureInputReducer.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import Combine
+import ComposableArchitecture
+
+public struct ExpenditureInputReducer: Reducer {
+    public struct State: Equatable {
+        @BindingState var text: String = ""
+    }
+
+    public enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+    }
+    public var body: some ReducerOf<ExpenditureInputReducer> {
+        BindingReducer()
+
+        Reduce { _, action in
+            switch action {
+                default: return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/ExpendpenditureInputReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/ExpendpenditureInputReducer.swift
@@ -7,10 +7,13 @@
 
 import Combine
 import ComposableArchitecture
+import DesignSystem
 
 public struct ExpenditureInputReducer: Reducer {
     public struct State: Equatable {
         @BindingState var text: String = ""
+        var currency: Double = 0.05
+        var currencyText: String = "= 0원"
     }
 
     public enum Action: BindableAction, Equatable {
@@ -19,10 +22,21 @@ public struct ExpenditureInputReducer: Reducer {
     public var body: some ReducerOf<ExpenditureInputReducer> {
         BindingReducer()
 
-        Reduce { _, action in
+        Reduce { state, action in
             switch action {
-                default: return .none
+            case .binding(\.$text):
+                if state.text.count < 10 {
+                    let convertedCurrency = Int((Double(state.text) ?? 0.0) * state.currency)
+                    let formattedText = convertedCurrency.formattedWithSeparator
+                    state.currencyText = "= \(formattedText)원"
+                } else {
+                    state.currencyText = "나타낼 수 없습니다."
+                }
+                return .none
+            default:
+                return .none
             }
         }
     }
 }
+

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/ExpendpenditureInputView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/ExpendpenditureInputView.swift
@@ -25,12 +25,16 @@ extension ExpenditureInputView {
     var containerView: some View {
         WithViewStore(store, observe: { $0 }) { viewstore in
             VStack(alignment: .leading, spacing: 10) {
-                Text("유로")
-                    .foregroundColor(.ybColor(.gray6))
-                    .font(.ybfont(.body3))
+                Button {
+                    // tapp
+                } label: {
+                    Text("유로")
+                        .foregroundColor(.ybColor(.gray6))
+                        .font(.ybfont(.body3))
+                }
                 VStack(alignment: .leading, spacing: 0) {
                     CurrencyTextFieldView(text: viewstore[keyPath: \.$text], placeholder: "0 $")
-                    Text("= 1000원")
+                    Text(viewstore.currencyText)
                         .foregroundColor(.ybColor(.gray3))
                         .font(.ybfont(.body2))
                 }

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/ExpendpenditureInputView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditureInput/ExpendpenditureInputView.swift
@@ -1,0 +1,43 @@
+//
+//  ExpendpenditureInputView.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import SwiftUI
+import ComposableArchitecture
+import DesignSystem
+
+struct ExpenditureInputView: View {
+    typealias State = ExpenditureInputReducer.State
+    typealias Action = ExpenditureInputReducer.Action
+
+    let store: StoreOf<ExpenditureInputReducer>
+
+    var body: some View {
+        containerView
+            .padding(.horizontal, 24)
+    }
+}
+
+extension ExpenditureInputView {
+    var containerView: some View {
+        WithViewStore(store, observe: { $0 }) { viewstore in
+            VStack(alignment: .leading, spacing: 10) {
+                Text("유로")
+                    .foregroundColor(.ybColor(.gray6))
+                    .font(.ybfont(.body3))
+                VStack(alignment: .leading, spacing: 0) {
+                    CurrencyTextFieldView(text: viewstore[keyPath: \.$text], placeholder: "0 $")
+                    Text("= 1000원")
+                        .foregroundColor(.ybColor(.gray3))
+                        .font(.ybfont(.body2))
+                }
+            }
+            .padding(22)
+            .background(YBColor.white.swiftUIColor)
+            .cornerRadius(10)
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditurePayment/ExpenditurePaymentReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditurePayment/ExpenditurePaymentReducer.swift
@@ -1,0 +1,32 @@
+//
+//  ExpenditurePaymentReducer.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import Combine
+import ComposableArchitecture
+
+public enum Payment {
+    case cash, card
+}
+
+public struct ExpenditurePaymentReducer: Reducer {
+    public struct State: Equatable {
+        var seletedPayment: Payment = .cash
+    }
+
+    public enum Action: Equatable {
+        case setPayment(Payment)
+    }
+    public var body: some ReducerOf<ExpenditurePaymentReducer> {
+        Reduce { state, action in
+            switch action {
+            case let .setPayment(payment):
+                state.seletedPayment = payment
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/ExpenditurePayment/ExpenditurePaymentView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/ExpenditurePayment/ExpenditurePaymentView.swift
@@ -1,0 +1,71 @@
+//
+//  ExpenditurePaymentView.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import SwiftUI
+import ComposableArchitecture
+import DesignSystem
+
+struct ExpenditurePaymentView: View {
+    typealias State = ExpenditurePaymentReducer.State
+    typealias Action = ExpenditurePaymentReducer.Action
+
+    let store: StoreOf<ExpenditurePaymentReducer>
+
+    var body: some View {
+        containerView
+    }
+}
+
+extension ExpenditurePaymentView {
+
+    var containerView: some View {
+        HStack(alignment: .center, spacing: 10) {
+            HStack(spacing: 0) {
+                Text("지출형태")
+                    .foregroundColor(.ybColor(.black))
+                    .font(.ybfont(.title1))
+                Text("*")
+                    .foregroundColor(.ybColor(.mainGreen))
+                    .font(.ybfont(.body3))
+            }
+            Spacer()
+            HStack(spacing: 12) {
+                paymentButtonView(type: .cash)
+                paymentButtonView(type: .card)
+            }
+        }
+        .padding(.horizontal, 24)
+    }
+
+
+    func paymentButtonView(type: Payment) -> some View {
+        WithViewStore(store, observe: \.seletedPayment) { viewstore in
+            Button(action: {
+                viewstore.send(.setPayment(type))
+            }, label: {
+                Text(type.text)
+                    .foregroundColor(type == viewstore.state ? .ybColor(.white) : .ybColor(.black))
+                    .font(.ybfont(.body1))
+                    .frame(width: 90, height: 44)
+            })
+            .background(type == viewstore.state ? YBColor.gray6.swiftUIColor : YBColor.gray3.swiftUIColor)
+            .cornerRadius(10)
+        }
+
+    }
+
+
+}
+
+extension Payment {
+    var text: String {
+        switch self {
+        case .cash: return "현금"
+        case .card: return "카드"
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/HostingController/ExpenditureReducer.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/HostingController/ExpenditureReducer.swift
@@ -1,0 +1,43 @@
+//
+//  ExpenditureReducer.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import Combine
+import ComposableArchitecture
+
+public enum ExpenditureTab: Equatable {
+    case individual, shared
+}
+
+public struct ExpenditureReducer: Reducer {
+    public struct State: Equatable {
+        @BindingState var seletedExpenditureType: ExpenditureTab = .individual
+        var expenditureEdit = ExpendpenditureEditReducer.State()
+
+        public init(seletedExpenditureType: ExpenditureTab) {
+            self.seletedExpenditureType = seletedExpenditureType
+        }
+    }
+
+    public enum Action: BindableAction, Equatable {
+        case binding(BindingAction<ExpenditureReducer.State>)
+        case expenditureEdit(ExpendpenditureEditReducer.Action)
+    }
+
+    public var body: some ReducerOf<ExpenditureReducer> {
+        BindingReducer()
+
+        Reduce { _, action in
+            switch action {
+                default: return .none
+            }
+        }
+
+        Scope(state: \.expenditureEdit, action: /Action.expenditureEdit) {
+            ExpendpenditureEditReducer()
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/HostingController/ExpenditureView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/HostingController/ExpenditureView.swift
@@ -1,0 +1,57 @@
+//
+//  ExpenditureView.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import SwiftUI
+import UIKit
+import ComposableArchitecture
+import DesignSystem
+
+final class ExpenditureHostingController: UIHostingController<ExpenditureView> {
+}
+
+struct ExpenditureView: View {
+    typealias State = ExpenditureReducer.State
+    typealias Action = ExpenditureReducer.Action
+
+    let store: StoreOf<ExpenditureReducer>
+
+    var body: some View {
+        containerView
+    }
+}
+
+extension ExpenditureView {
+
+    @MainActor
+    var containerView: some View {
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            VStack(spacing: 10) {
+                ExpenditureToggleView(expenditureTab: viewStore.$seletedExpenditureType)
+                .frame(height: 40)
+                .padding(.horizontal, 24)
+                TabView(selection: viewStore.$seletedExpenditureType) {
+                    ExpendpenditureEditView(
+                       store: store.scope(
+                        state: \.expenditureEdit,
+                        action: ExpenditureReducer.Action.expenditureEdit
+                       )
+                    )
+                    .tag(ExpenditureTab.shared)
+                    ExpendpenditureEditView(
+                       store: store.scope(
+                        state: \.expenditureEdit,
+                        action: ExpenditureReducer.Action.expenditureEdit
+                       )
+                    )
+                    .tag(ExpenditureTab.individual)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+            }
+            .background(YBColor.gray1.swiftUIColor)
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/HostingController/ExpenditureView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/HostingController/ExpenditureView.swift
@@ -51,7 +51,7 @@ extension ExpenditureView {
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
             }
-            .background(YBColor.gray1.swiftUIColor)
+            .background(YBColor.gray1.swiftUIColor, ignoresSafeAreaEdges: [.all])
         }
     }
 }

--- a/Projects/Features/ExpenditureEdit/Sources/Toggle/ExpenditureToggleView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/Toggle/ExpenditureToggleView.swift
@@ -1,0 +1,74 @@
+//
+//  ExpenditureToggleView.swift
+//  Expenditure
+//
+//  Created Hoyoung Lee on 1/6/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+
+import SwiftUI
+import DesignSystem
+
+struct ExpenditureToggleView: View {
+    @Binding var expenditureTab: ExpenditureTab
+
+    init(expenditureTab: Binding<ExpenditureTab>) {
+        self._expenditureTab = expenditureTab
+    }
+    var body: some View {
+        GeometryReader { reader in
+            ZStack {
+                HStack(spacing: 0) {
+                    if expenditureTab == .individual {
+                        Spacer(minLength: 0)
+                    }
+                    VStack {
+                        Rectangle()
+                            .fill(Color.white)
+                            .cornerRadius(10)
+                    }
+                    .frame(width: reader.frame(in: .global).width / 2)
+                    .padding(4)
+                    if expenditureTab == .shared {
+                        Spacer(minLength: 0)
+                    }
+                }
+                .animation(.default, value: expenditureTab)
+                HStack(spacing: 0) {
+                    Button {
+                        withAnimation {
+                            expenditureTab.toggle()
+                        }
+                    } label: {
+                        Text("공동")
+                            .foregroundColor(.ybColor(.gray6))
+                            .font(.ybfont(.body3))
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                    Button {
+                        withAnimation {
+                            expenditureTab.toggle()
+                        }
+                    } label: {
+                        Text("개인")
+                            .foregroundColor(.ybColor(.gray6))
+                            .font(.ybfont(.body3))
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                }
+            }
+            .background(YBColor.gray2.swiftUIColor)
+            .cornerRadius(10)
+        }
+    }
+}
+
+extension ExpenditureTab {
+    mutating func toggle() {
+        switch self {
+        case .shared:
+            self = .individual
+        case .individual:
+            self = .shared
+        }
+    }
+}

--- a/Projects/Features/ExpenditureEdit/Sources/Toggle/ExpenditureToggleView.swift
+++ b/Projects/Features/ExpenditureEdit/Sources/Toggle/ExpenditureToggleView.swift
@@ -39,7 +39,7 @@ struct ExpenditureToggleView: View {
                             expenditureTab.toggle()
                         }
                     } label: {
-                        Text("공동")
+                        Text("지출 추가")
                             .foregroundColor(.ybColor(.gray6))
                             .font(.ybfont(.body3))
                             .frame(maxWidth: .infinity, alignment: .center)
@@ -49,7 +49,7 @@ struct ExpenditureToggleView: View {
                             expenditureTab.toggle()
                         }
                     } label: {
-                        Text("개인")
+                        Text("내예산 추가")
                             .foregroundColor(.ybColor(.gray6))
                             .font(.ybfont(.body3))
                             .frame(maxWidth: .infinity, alignment: .center)

--- a/Projects/Features/ExpenditureEdit/Tests/ExpenditureEditTests.swift
+++ b/Projects/Features/ExpenditureEdit/Tests/ExpenditureEditTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class ExpenditureEditTests: XCTestCase {
+    func test_example() {
+        XCTAssertEqual("ExpenditureEdit", "ExpenditureEdit")
+    }
+}

--- a/Projects/YeoBee/Resources/Colors.xcassets/AppIcon.appiconset/Contents.json
+++ b/Projects/YeoBee/Resources/Colors.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/TargetDependencyExtension.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependencyExtension.swift
@@ -32,6 +32,9 @@ public extension TargetDependency {
     static let onboarding: TargetDependency = .project(
         target: "Onboarding",
         path: .relativeToRoot("Projects/Features/Onboarding"))
+    static let expenditureEdit: TargetDependency = .project(
+        target: "ExpenditureEdit",
+        path: .relativeToRoot("Projects/Features/ExpenditureEdit"))
 }
 
 // MARK: Package


### PR DESCRIPTION
## 이슈번호
[YB-84]

## 수정 사항
- 개인 지출 등록 화면의 텍스트필드, 지출 형태, 카테고리, 지출항목 화면을 구현하였습니다
- 지출 항목 커서 활성화 시 스크롤 되도록 구현하였습니다

## 화면 (Optional)
| 전체 화면 | 금액 입력 | focus scroll |
| --- | --- | --- |
| <img width="336" alt="스크린샷 2024-01-07 오후 6 57 45" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/40068674/f46410d9-8eda-4856-aaae-ce96200873f0"> | ![Simulator Screen Recording - iPhone 15 Pro - 2024-01-07 at 18 06 57](https://github.com/YAPP-Github/YeoBee-iOS/assets/40068674/200e1e4c-e88e-47cb-a8df-56185a98fc49) | ![Simulator Screen Recording - iPhone 15 Pro - 2024-01-07 at 18 05 45](https://github.com/YAPP-Github/YeoBee-iOS/assets/40068674/6e072ad9-8300-45f1-a8a6-6249c3eae350) |

## target module
- ExpenditureEdit

## 참고사항
카테고리 선택 시 나머지는 회색으로 처리하려고 했는데 tint 적용이 안되어서 image asset 변경할 예정입니다
