### PR TITLE
[YB-98] 동행 선택 화면 동행자 추가

### DIFF
--- a/Projects/DesignSystem/Sources/Button/YBPaddingButton.swift
+++ b/Projects/DesignSystem/Sources/Button/YBPaddingButton.swift
@@ -11,12 +11,30 @@ import UIKit
 public final class YBPaddingButton: UIButton {
     
     private let padding: UIEdgeInsets
+    private var gradientLayer: CAGradientLayer?
     
-    public init(text: String, padding: Padding = .medium) {
+    public init(text: String,
+                font: YBFont = .body2,
+                titleColor: YBColor = .gray4,
+                selectedTitleColor: YBColor = .white,
+                backgroundColor: YBColor = .gray2,
+                selectedBgColor: YBColor = .black,
+                gradient: Bool,
+                padding: Padding = .medium) {
         self.padding = padding.insets
         super.init(frame: .zero)
         setTitle(text, for: .normal)
-        configure(padding: padding)
+        if gradient {
+            configureGradient(ft: font, padding: padding)
+        } else {
+            configure(ft: font,
+                      titleColor: titleColor,
+                      selectedTitleColor: selectedTitleColor,
+                      bgColor: backgroundColor,
+                      selectedBgColor: selectedBgColor,
+                      padding: padding)
+        }
+        clipsToBounds = true
     }
     
     @available(*, unavailable)
@@ -26,6 +44,9 @@ public final class YBPaddingButton: UIButton {
     
     public override func draw(_ rect: CGRect) {
         super.draw(rect.inset(by: padding))
+        if let gradientLayer = gradientLayer {
+            gradientLayer.frame = bounds
+        }
     }
     
     public override var intrinsicContentSize: CGSize {
@@ -36,27 +57,58 @@ public final class YBPaddingButton: UIButton {
         return contentSize
     }
     
-    func configure(padding: Padding) {
-        titleLabel?.font = YBFont.body2.font
-        setTitleColor(YBColor.gray4.color, for: .normal)
-        setBackgroundColor(YBColor.gray2.color, for: .normal)
-        setTitleColor(YBColor.white.color, for: .highlighted)
-        setBackgroundColor(YBColor.black.color, for: .highlighted)
-        setTitleColor(YBColor.white.color, for: .selected)
-        setBackgroundColor(YBColor.black.color, for: .selected)
+    
+    
+    func configureGradient(ft: YBFont, padding: Padding) {
+        setTitleColor(YBColor.white.color, for: .normal)
+        titleLabel?.font = ft.font
+        let gradientColors = [YBColor.mediumGreen.color, YBColor.mainGreen.color]
+        let startPoint = CGPoint(x: 0, y: 0)
+        let endPoint = CGPoint(x: 1, y: 1)
+        
+        gradientLayer = CAGradientLayer()
+        gradientLayer?.frame = bounds
+        gradientLayer?.colors = gradientColors.map { $0.cgColor }
+        gradientLayer?.startPoint = startPoint
+        gradientLayer?.endPoint = endPoint
+        paddingForRadius(padding: padding)
+        if let gradientLayer = gradientLayer {
+            layer.insertSublayer(gradientLayer, at: 0)
+        }
+    }
+    
+    func configure(ft: YBFont,
+                   titleColor: YBColor,
+                   selectedTitleColor: YBColor,
+                   bgColor: YBColor,
+                   selectedBgColor: YBColor,
+                   padding: Padding) {
+        titleLabel?.font = ft.font
+        setTitleColor(titleColor.color, for: .normal)
+        setBackgroundColor(bgColor.color, for: .normal)
+        setTitleColor(selectedTitleColor.color, for: .highlighted)
+        setBackgroundColor(selectedBgColor.color, for: .highlighted)
+        setTitleColor(selectedTitleColor.color, for: .selected)
+        setBackgroundColor(selectedBgColor.color, for: .selected)
+        paddingForRadius(padding: padding)
+        
+    }
+    
+    private func paddingForRadius(padding: Padding) {
         switch padding {
         case .small:
-            layer.cornerRadius = 14
+            return layer.cornerRadius = 14
         case .medium:
-            layer.cornerRadius = 16
+            return layer.cornerRadius = 16
         case .large:
-            layer.cornerRadius = 18
+            return layer.cornerRadius = 18
         case .calendarDate:
-            layer.cornerRadius = 16
+            return layer.cornerRadius = 20
+        case .gradient:
+            return layer.cornerRadius = 20
         case .custom:
-            layer.cornerRadius = 15
+            return layer.cornerRadius = 15
         }
-        clipsToBounds = true
     }
     
     func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
@@ -75,6 +127,7 @@ public enum Padding {
     case medium
     case large
     case calendarDate
+    case gradient
     case custom(top: CGFloat, left: CGFloat, bottom: CGFloat, right: CGFloat)
     
     var insets: UIEdgeInsets {
@@ -87,6 +140,8 @@ public enum Padding {
             return UIEdgeInsets(top: 12, left: 24, bottom: 12, right: 24)
         case .calendarDate:
             return UIEdgeInsets(top: 7.5, left: 14, bottom: 7.5, right: 14)
+        case .gradient:
+            return UIEdgeInsets(top: 6.5, left: 14, bottom: 6.5, right: 14)
         case .custom(let top, let left, let bottom, let right):
             return UIEdgeInsets(top: top, left: left, bottom: bottom, right: right)
         }

--- a/Projects/DesignSystem/Sources/Button/YBPaddingButton.swift
+++ b/Projects/DesignSystem/Sources/Button/YBPaddingButton.swift
@@ -44,7 +44,7 @@ public final class YBPaddingButton: UIButton {
     
     public override func draw(_ rect: CGRect) {
         super.draw(rect.inset(by: padding))
-        if let gradientLayer = gradientLayer {
+        if let gradientLayer {
             gradientLayer.frame = bounds
         }
     }
@@ -56,8 +56,6 @@ public final class YBPaddingButton: UIButton {
         contentSize.width += padding.left + padding.right
         return contentSize
     }
-    
-    
     
     func configureGradient(font: YBFont, padding: Padding) {
         setTitleColor(YBColor.white.color, for: .normal)

--- a/Projects/DesignSystem/Sources/Button/YBPaddingButton.swift
+++ b/Projects/DesignSystem/Sources/Button/YBPaddingButton.swift
@@ -19,15 +19,15 @@ public final class YBPaddingButton: UIButton {
                 selectedTitleColor: YBColor = .white,
                 backgroundColor: YBColor = .gray2,
                 selectedBgColor: YBColor = .black,
-                gradient: Bool,
+                isGradient: Bool,
                 padding: Padding = .medium) {
         self.padding = padding.insets
         super.init(frame: .zero)
         setTitle(text, for: .normal)
-        if gradient {
-            configureGradient(ft: font, padding: padding)
+        if isGradient {
+            configureGradient(font: font, padding: padding)
         } else {
-            configure(ft: font,
+            configure(font: font,
                       titleColor: titleColor,
                       selectedTitleColor: selectedTitleColor,
                       bgColor: backgroundColor,
@@ -59,9 +59,9 @@ public final class YBPaddingButton: UIButton {
     
     
     
-    func configureGradient(ft: YBFont, padding: Padding) {
+    func configureGradient(font: YBFont, padding: Padding) {
         setTitleColor(YBColor.white.color, for: .normal)
-        titleLabel?.font = ft.font
+        titleLabel?.font = font.font
         let gradientColors = [YBColor.mediumGreen.color, YBColor.mainGreen.color]
         let startPoint = CGPoint(x: 0, y: 0)
         let endPoint = CGPoint(x: 1, y: 1)
@@ -77,13 +77,13 @@ public final class YBPaddingButton: UIButton {
         }
     }
     
-    func configure(ft: YBFont,
+    func configure(font: YBFont,
                    titleColor: YBColor,
                    selectedTitleColor: YBColor,
                    bgColor: YBColor,
                    selectedBgColor: YBColor,
                    padding: Padding) {
-        titleLabel?.font = ft.font
+        titleLabel?.font = font.font
         setTitleColor(titleColor.color, for: .normal)
         setBackgroundColor(bgColor.color, for: .normal)
         setTitleColor(selectedTitleColor.color, for: .highlighted)

--- a/Projects/DesignSystem/Sources/Label/YBPaddingLabel.swift
+++ b/Projects/DesignSystem/Sources/Label/YBPaddingLabel.swift
@@ -60,7 +60,9 @@ public final class YBPaddingLabel: UILabel {
         case .large:
             layer.cornerRadius = 18
         case .calendarDate:
-            layer.cornerRadius = 16
+            layer.cornerRadius = 20
+        case .gradient:
+            layer.cornerRadius = 20
         case .custom:
             layer.cornerRadius = 15
         }

--- a/Projects/DesignSystem/Sources/Label/YBPaddingLabel.swift
+++ b/Projects/DesignSystem/Sources/Label/YBPaddingLabel.swift
@@ -21,7 +21,7 @@ public final class YBPaddingLabel: UILabel {
         configure(bgColor: backgroundColor,
                   txtColor: textColor,
                   brdColor: borderColor,
-                  ft: font,
+                  font: font,
                   padding: padding)
     }
     
@@ -42,10 +42,10 @@ public final class YBPaddingLabel: UILabel {
         return contentSize
     }
     
-    func configure(bgColor: YBColor, txtColor: YBColor, brdColor: YBColor? = nil, ft: YBFont, padding: Padding) {
+    func configure(bgColor: YBColor, txtColor: YBColor, brdColor: YBColor? = nil, font: YBFont, padding: Padding) {
         self.backgroundColor = bgColor.color
         self.textColor = txtColor.color
-        self.font = ft.font
+        self.font = font.font
         
         if brdColor != nil {
             self.layer.borderColor = brdColor?.color.cgColor

--- a/Projects/Features/TravelRegistration/Sources/Domain/Entities/Companion.swift
+++ b/Projects/Features/TravelRegistration/Sources/Domain/Entities/Companion.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Companion: Hashable, Equatable {
+public struct Companion: Hashable {
     var name: String
     var imageURL: String
     

--- a/Projects/Features/TravelRegistration/Sources/Domain/Entities/Companion.swift
+++ b/Projects/Features/TravelRegistration/Sources/Domain/Entities/Companion.swift
@@ -1,0 +1,18 @@
+//
+//  Companion.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/10/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import Foundation
+
+public struct Companion: Hashable, Equatable {
+    var name: String
+    var imageURL: String
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Domain/Entities/Country.swift
+++ b/Projects/Features/TravelRegistration/Sources/Domain/Entities/Country.swift
@@ -68,13 +68,9 @@ public enum CountryType: String, CaseIterable {
                                                      Country(name: "아프리카국가3", imageURL: "이미지URL3")]
 }
 
-public struct Country: Hashable, Equatable {
+public struct Country: Hashable {
     var name: String
     var imageURL: String
-    
-    public static func  == (lhs: Country, rhs: Country) -> Bool {
-        lhs.name == rhs.name
-    }
     
     public func hash(into hasher: inout Hasher) {
         hasher.combine(name)

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarViewController.swift
@@ -279,8 +279,9 @@ extension CalendarViewController: View {
     func bindAction(reactor: CalendarReactor) {
         nextButton.rx.tap
             .observe(on: MainScheduler.instance)
-            .bind { _ in
-                print("nextButton Tap")
+            .bind { [weak self] _ in
+                let companionVC = CompanionViewController()
+                self?.navigationController?.pushViewController(companionVC, animated: true)
             }.disposed(by: disposeBag)
     }
     

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionReactor.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionReactor.swift
@@ -59,7 +59,7 @@ public final class CompanionReactor: Reactor {
             }
             newState.companions.append(.init(name: "사용자\(state.companions.count+1)", imageURL: ""))
         case .deleteCompanion(let companion):
-            if let companionsIndex = newState.companions.firstIndex(where: { $0.name == companion.name }) {
+            if let companionsIndex = newState.companions.firstIndex(where: { $0 == companion }) {
                 newState.companions.remove(at: companionsIndex)
             }
         }

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionReactor.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionReactor.swift
@@ -1,0 +1,69 @@
+//
+//  CompanionReactor.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/8/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+import ReactorKit
+import RxSwift
+import RxCocoa
+
+public final class CompanionReactor: Reactor {
+    
+    public enum Action {
+        case companionType(CompanionType)
+        case addCompanion
+        case deleteCompanion(Companion)
+    }
+    
+    public enum Mutation {
+        case companionType(CompanionType)
+        case addCompanion
+        case deleteCompanion(Companion)
+    }
+    
+    public struct State {
+        var companionType: CompanionType = .none
+        var companions: [Companion] = []
+    }
+    
+    public var initialState: State = State()
+    
+    
+    // MARK: - Mutate
+    public func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .companionType(let type):
+            return .just(.companionType(type))
+        case .addCompanion:
+            return .just(.addCompanion)
+        case .deleteCompanion(let companion):
+            return .just(.deleteCompanion(companion))
+        }
+    }
+    
+    // MARK: Reduce
+    public func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+            
+        switch mutation {
+        case .companionType(let type):
+            newState.companionType = type
+        case .addCompanion:
+            if newState.companions.count >= 9 {
+                print("9명 이상 안되는 토스트 실행")
+                break
+            }
+            newState.companions.append(.init(name: "사용자\(state.companions.count+1)", imageURL: ""))
+        case .deleteCompanion(let companion):
+            if let companionsIndex = newState.companions.firstIndex(where: { $0.name == companion.name }) {
+                newState.companions.remove(at: companionsIndex)
+            }
+        }
+        
+        return newState
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionReactor.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionReactor.swift
@@ -32,7 +32,6 @@ public final class CompanionReactor: Reactor {
     
     public var initialState: State = State()
     
-    
     // MARK: - Mutate
     public func mutate(action: Action) -> Observable<Mutation> {
         switch action {

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionViewController.swift
@@ -120,13 +120,16 @@ public final class CompanionViewController: TravelRegistrationController {
     }
     
     private func setDataSource() {
-        dataSource = UITableViewDiffableDataSource<CompanionSection, CompanionDataItem>(tableView: self.companionTableView) { (tableView, indexPath, companionDataItem) -> UITableViewCell? in
+        dataSource = UITableViewDiffableDataSource<CompanionSection, CompanionDataItem>(tableView: self.companionTableView) 
+        { (tableView, indexPath, companionDataItem) -> UITableViewCell? in
             var companion: Companion
             switch companionDataItem {
             case .main(let mainCompanion):
                 companion = mainCompanion
             }
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: CompanionTableViewCell.identifier, for: indexPath) as? CompanionTableViewCell else { return UITableViewCell() }
+            
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: CompanionTableViewCell.identifier,
+                                                           for: indexPath) as? CompanionTableViewCell else { return UITableViewCell() }
             cell.delegate = self
             cell.companion = companion
             return cell

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionViewController.swift
@@ -1,0 +1,239 @@
+//
+//  CompanionViewController.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/8/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+import ReactorKit
+import RxSwift
+import RxCocoa
+import SnapKit
+
+enum CompanionSection: CaseIterable {
+    case main
+}
+
+enum CompanionDataItem: Hashable {
+    case main(Companion)
+}
+
+public enum CompanionType: CaseIterable {
+    case none
+    case companion
+    case alone
+}
+
+public final class CompanionViewController: TravelRegistrationController {
+    
+    public var disposeBag = DisposeBag()
+    private let reactor = CompanionReactor()
+    var dataSource: UITableViewDiffableDataSource<CompanionSection, CompanionDataItem>!
+    
+    // MARK: - Properties
+    private let titleLabel = YBLabel(text: "여행을 함께 하는 동행이 있나요?", font: .header2, textColor: .black)
+    private let subTitleLabel = YBLabel(text: "나중에 변경이 어려워요.", font: .body2, textColor: .gray5)
+    var companionButton = YBTextButton(text: "있어요", appearance: .selectDisable, size: .medium)
+    let aloneButton = YBTextButton(text: "혼자가요", appearance: .selectDisable, size: .medium)
+    private lazy var buttonStackView: UIStackView = {
+        $0.axis = .horizontal
+        $0.spacing = 15
+        $0.alignment = .center
+        $0.distribution = .fillEqually
+        return $0
+    }(UIStackView())
+    private let addCompanionView = AddCompanionView()
+    private let companionTableView = CompanionTableView()
+    private let dividerView = YBDivider(height: 0.6,
+                                        color: .gray3)
+    private var nextButton = YBTextButton(text: "다음으로",
+                                          appearance: .defaultDisable,
+                                          size: .medium)
+    
+    // MARK: - Life Cycles
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        addViews()
+        setLayouts()
+        bind(reactor: reactor)
+        setDataSource()
+        addCompanionView.configure() // 임시 내 프로필 데이터 설정
+    }
+    
+    // MARK: - Set UI
+    private func addViews() {
+        [
+            titleLabel,
+            subTitleLabel,
+            buttonStackView,
+            addCompanionView,
+            companionTableView,
+            dividerView,
+            nextButton
+        ].forEach {
+            view.addSubview($0)
+        }
+        
+        [
+            companionButton,
+            aloneButton
+        ].forEach {
+            buttonStackView.addArrangedSubview($0)
+        }
+    }
+    
+    private func setLayouts() {
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(24)
+            make.leading.equalToSuperview().inset(24)
+        }
+        subTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).inset(-6)
+            make.leading.equalTo(titleLabel.snp.leading)
+        }
+        buttonStackView.snp.makeConstraints { make in
+            make.top.equalTo(subTitleLabel.snp.bottom).inset(-20)
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.height.equalTo(54)
+        }
+        addCompanionView.snp.makeConstraints { make in
+            make.top.equalTo(buttonStackView.snp.bottom).inset(-30)
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.height.equalTo(100)
+        }
+        nextButton.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(10)
+            make.leading.trailing.equalToSuperview().inset(24)
+        }
+        dividerView.snp.makeConstraints { make in
+            make.bottom.equalTo(nextButton.snp.top).inset(-16)
+            make.leading.trailing.equalToSuperview()
+        }
+        companionTableView.snp.makeConstraints { make in
+            make.top.equalTo(addCompanionView.snp.bottom)
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.bottom.equalTo(dividerView.snp.top)
+        }
+    }
+    
+    private func setDataSource() {
+        dataSource = UITableViewDiffableDataSource<CompanionSection, CompanionDataItem>(tableView: self.companionTableView) { (tableView, indexPath, companionDataItem) -> UITableViewCell? in
+            var companion: Companion
+            switch companionDataItem {
+            case .main(let mainCompanion):
+                companion = mainCompanion
+            }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: CompanionTableViewCell.identifier, for: indexPath) as? CompanionTableViewCell else { return UITableViewCell() }
+            cell.delegate = self
+            cell.companion = companion
+            return cell
+        }
+
+        companionTableView.dataSource = dataSource
+    }
+    
+    private func configureSnapshot(companions: [Companion]) {
+        var snapshot = NSDiffableDataSourceSnapshot<CompanionSection, CompanionDataItem>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(companions.map { .main($0) }, toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: false)
+        
+        // 테이블 뷰 들어온 셀 자동 스크롤
+        if !companions.isEmpty {
+            let lastIndexPath = IndexPath(row: companions.count - 1, section: 0)
+            companionTableView.scrollToRow(at: lastIndexPath, at: .bottom, animated: true)
+        }
+    }
+}
+
+// MARK: - CompanionTableViewCellDelegate
+extension CompanionViewController: CompanionTableViewCellDelegate {
+    func deleteCompanion(companion: Companion) {
+        Observable.just(companion)
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind { [weak self] companion in
+                self?.reactor.action.onNext(.deleteCompanion(companion))
+            }.disposed(by: disposeBag)
+    }
+}
+
+// MARK: - Bind
+extension CompanionViewController: View {
+    public func bind(reactor: CompanionReactor) {
+        bindAction(reactor: reactor)
+        bindState(reactor: reactor)
+    }
+    
+    func bindAction(reactor: CompanionReactor) {
+        companionButton.rx.tap
+            .map { Reactor.Action.companionType(.companion) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        aloneButton.rx.tap
+            .map { Reactor.Action.companionType(.alone) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        addCompanionView.addCompanionButton.rx.tap
+            .map { Reactor.Action.addCompanion }
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+    }
+    
+    func bindState(reactor: CompanionReactor) {
+        reactor.state
+            .map { $0.companions }
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] companions in
+                self?.configureSnapshot(companions: companions)
+                if companions.isEmpty {
+                    self?.nextButton.setTitle("다음으로", for: .normal)
+                    self?.nextButton.isEnabled = false
+                    self?.nextButton.setAppearance(appearance: .defaultDisable)
+                } else {
+                    self?.nextButton.setTitle("다음으로", for: .normal)
+                    self?.nextButton.isEnabled = true
+                    self?.nextButton.setAppearance(appearance: .default)
+                }
+            }.disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.companionType }
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] companionType in
+                switch companionType {
+                case .none:
+                    self?.addCompanionView.alpha = 0
+                    self?.companionTableView.alpha = 0
+                case .companion:
+                    self?.addCompanionView.alpha = 1
+                    self?.companionTableView.alpha = 1
+                    self?.companionButton.setTitle("있어요", for: .normal)
+                    self?.companionButton.setAppearance(appearance: .select)
+                    self?.aloneButton.setTitle("혼자가요", for: .normal)
+                    self?.aloneButton.setAppearance(appearance: .selectDisable)
+                    if reactor.currentState.companions.isEmpty {
+                        self?.nextButton.setTitle("다음으로", for: .normal)
+                        self?.nextButton.isEnabled = false
+                        self?.nextButton.setAppearance(appearance: .defaultDisable)
+                    }
+                case .alone:
+                    self?.addCompanionView.alpha = 0
+                    self?.companionTableView.alpha = 0
+                    self?.companionButton.setTitle("있어요", for: .normal)
+                    self?.companionButton.setAppearance(appearance: .selectDisable)
+                    self?.aloneButton.setTitle("혼자가요", for: .normal)
+                    self?.aloneButton.setAppearance(appearance: .select)
+                    self?.nextButton.setTitle("다음으로", for: .normal)
+                    self?.nextButton.isEnabled = true
+                    self?.nextButton.setAppearance(appearance: .default)
+                }
+            }.disposed(by: disposeBag)
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/CompanionViewController.swift
@@ -102,7 +102,7 @@ public final class CompanionViewController: TravelRegistrationController {
         addCompanionView.snp.makeConstraints { make in
             make.top.equalTo(buttonStackView.snp.bottom).inset(-30)
             make.leading.trailing.equalToSuperview().inset(24)
-            make.height.equalTo(100)
+            make.height.equalTo(105)
         }
         nextButton.snp.makeConstraints { make in
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(10)

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/AddCompanionView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/AddCompanionView.swift
@@ -1,0 +1,73 @@
+//
+//  AddCompanionView.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/8/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+import SnapKit
+
+final class AddCompanionView: UIView {
+    private let addCompanionLabel = YBLabel(text: "동행을 추가해주세요.", font: .header2, textColor: .black)
+    
+    let addCompanionButton = YBPaddingButton(text: "+  추가", gradient: true, padding: .gradient)
+    
+    private let myProfileImageView: UIImageView = {
+        $0.layer.cornerRadius = 22
+        $0.clipsToBounds = true
+        return $0
+    }(UIImageView())
+    
+    private let myProfileNameLabel = YBLabel(font: .body1, textColor: .black)
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addViews()
+        setLayouts()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("Not implemented xib init")
+    }
+    
+    // MARK: - Set UI
+    private func addViews() {
+        [
+            addCompanionLabel,
+            addCompanionButton,
+            myProfileImageView,
+            myProfileNameLabel
+        ].forEach {
+            addSubview($0)
+        }
+    }
+    
+    private func setLayouts() {
+        addCompanionButton.snp.makeConstraints { make in
+            make.top.trailing.equalToSuperview()
+        }
+        addCompanionLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview()
+            make.centerY.equalTo(addCompanionButton.snp.centerY)
+        }
+        myProfileImageView.snp.makeConstraints { make in
+            make.top.equalTo(addCompanionLabel.snp.bottom).offset(20)
+            make.leading.equalToSuperview()
+            make.size.equalTo(44)
+        }
+        myProfileNameLabel.snp.makeConstraints { make in
+            make.leading.equalTo(myProfileImageView.snp.trailing).offset(12)
+            make.centerY.equalTo(myProfileImageView.snp.centerY)
+        }
+    }
+    
+    func configure() {
+        myProfileImageView.backgroundColor = .systemPink
+        myProfileNameLabel.text = "여비"
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/AddCompanionView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/AddCompanionView.swift
@@ -13,7 +13,7 @@ import SnapKit
 final class AddCompanionView: UIView {
     private let addCompanionLabel = YBLabel(text: "동행을 추가해주세요.", font: .header2, textColor: .black)
     
-    let addCompanionButton = YBPaddingButton(text: "+  추가", gradient: true, padding: .gradient)
+    let addCompanionButton = YBPaddingButton(text: "+  추가", isGradient: true, padding: .gradient)
     
     private let myProfileImageView: UIImageView = {
         $0.layer.cornerRadius = 22

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/CompanionTableView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/CompanionTableView.swift
@@ -1,0 +1,30 @@
+//
+//  CompanionTableView.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/9/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+
+final class CompanionTableView: UITableView {
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override init(frame: CGRect, style: UITableView.Style) {
+        super.init(frame: frame, style: style)
+        setView()
+    }
+    
+    private func setView() {
+        register(CompanionTableViewCell.self, forCellReuseIdentifier: CompanionTableViewCell.identifier)
+        showsVerticalScrollIndicator = false
+        backgroundColor = .clear
+        separatorInset.left = 0
+        rowHeight = 60
+        separatorStyle = .none
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/CompanionTableViewCell.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/CompanionTableViewCell.swift
@@ -1,0 +1,125 @@
+//
+//  CompanionTableViewCell.swift
+//  TravelRegistration
+//
+//  Created by 박현준 on 1/9/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+import RxSwift
+import RxCocoa
+
+protocol CompanionTableViewCellDelegate: AnyObject {
+    func deleteCompanion(companion: Companion)
+}
+
+class CompanionTableViewCell: UITableViewCell {
+    static let identifier = "CompanionTableViewCell"
+    weak var delegate: CompanionTableViewCellDelegate?
+    var disposeBag = DisposeBag()
+    
+    var companion: Companion? {
+        didSet {
+            configure()
+        }
+    }
+    
+    private let profileImageView: UIImageView = {
+        $0.backgroundColor = YBColor.brightGreen.color
+        $0.layer.cornerRadius = 22
+        $0.clipsToBounds = true
+        return $0
+    }(UIImageView())
+    
+    private let profileNameLabel = YBLabel(font: .body1, textColor: .black)
+    
+    let pencilButton: UIButton = {
+        $0.backgroundColor = YBColor.brightGreen.color
+        $0.layer.cornerRadius = 21
+        $0.clipsToBounds = true
+        $0.setTitle("추가", for: .normal)
+        $0.setTitleColor(YBColor.mainGreen.color, for: .normal)
+        $0.titleLabel?.font = YBFont.body2.font
+        return $0
+    }(UIButton())
+    
+    let deleteButton: UIButton = {
+        $0.backgroundColor = YBColor.brightRed.color
+        $0.layer.cornerRadius = 21
+        $0.clipsToBounds = true
+        $0.setTitle("삭제", for: .normal)
+        $0.setTitleColor(YBColor.mainRed.color, for: .normal)
+        $0.titleLabel?.font = YBFont.body2.font
+        return $0
+    }(UIButton())
+    
+    // MARK: - Lifecycle
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setView()
+        addViews()
+        setLayout()
+        bind()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        profileImageView.image = nil
+        profileNameLabel.text = ""
+    }
+    
+    // MARK: - Set UI
+    private func setView() {
+        selectionStyle = .none
+    }
+    
+    private func addViews() {
+        [
+            profileImageView,
+            profileNameLabel,
+            pencilButton,
+            deleteButton
+        ].forEach {
+            contentView.addSubview($0)
+        }
+    }
+    private func setLayout() {
+        profileImageView.snp.makeConstraints { make in
+            make.leading.centerY.equalToSuperview()
+            make.size.equalTo(44)
+        }
+        profileNameLabel.snp.makeConstraints { make in
+            make.leading.equalTo(profileImageView.snp.trailing).offset(12)
+            make.centerY.equalTo(profileImageView.snp.centerY)
+        }
+        deleteButton.snp.makeConstraints { make in
+            make.trailing.centerY.equalToSuperview()
+            make.size.equalTo(42)
+        }
+        pencilButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalTo(deleteButton.snp.leading).inset(-10)
+            make.size.equalTo(deleteButton.snp.size)
+        }
+    }
+    
+    func configure() {
+        guard let companion = companion else { return }
+        profileNameLabel.text = companion.name
+    }
+    
+    private func bind() {
+        deleteButton.rx.tap
+            .bind { [weak self] _ in
+                if let companion = self?.companion {
+                    self?.delegate?.deleteCompanion(companion: companion)
+                }
+            }.disposed(by: disposeBag)
+    }
+}
+

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Country/SubViews/HorizontalCountryView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Country/SubViews/HorizontalCountryView.swift
@@ -67,7 +67,7 @@ class HorizontalCountryView: UIScrollView {
     
     func bind() {
         CountryType.allCases.forEach { type in
-            let btn = YBPaddingButton(text: type.rawValue, padding: .small)
+            let btn = YBPaddingButton(text: type.rawValue, gradient: false, padding: .small)
             
             btn.rx.tap
                 .subscribe(onNext: { [weak self] in

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Country/SubViews/HorizontalCountryView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Country/SubViews/HorizontalCountryView.swift
@@ -67,7 +67,7 @@ class HorizontalCountryView: UIScrollView {
     
     func bind() {
         CountryType.allCases.forEach { type in
-            let btn = YBPaddingButton(text: type.rawValue, gradient: false, padding: .small)
+            let btn = YBPaddingButton(text: type.rawValue, isGradient: false, padding: .small)
             
             btn.rx.tap
                 .subscribe(onNext: { [weak self] in


### PR DESCRIPTION
## 이슈번호
[YB-98]

## 수정 사항
- DesignSystem YBPaddingButton에 Gradient 넣는 함수 추가했습니다.
- 추후에 연필, 휴지통 버튼 DesignSystem에 추가되면 한 번에 변경할 생각으로 임의로 버튼 만들어두었습니다.
- 최대 동행자 9명 까지 제한만 해둔 상태고 DesignSystem에 Toast 추가되면 설정하겠습니다.




## 화면 (Optional)
| 기본 | 동행있음(추가X) |
| --- | --- | 
|<img width="430" alt="스크린샷 2024-01-11 오전 12 18 30" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/6f2f1103-190b-4bb5-b01f-4b6572b7e645">| <img width="430" alt="스크린샷 2024-01-11 오전 12 19 00" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/0e967b6a-43eb-4a9c-875b-24f676a457f3">|


| 동행없음 | 동행있음(추가O) |
| --- | --- | 
|<img width="430" alt="스크린샷 2024-01-11 오전 12 19 02" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/23b7effd-9f0e-4de2-b7fc-e85a6e562e46">| <img width="430" alt="스크린샷 2024-01-11 오전 12 49 59" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/1f02efe6-f1a0-49d5-b7a6-08d97ea9ef9c">|

<img width="300" alt="스크린샷 2024-01-11 오전 12 25 12" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/5321ccf1-150c-41e2-993e-46145624aed9">


## target module
- TravelRegistration

## 참고사항
- 동행자 추가 후 이름 변경하는 로직은 다음 PR에 반영해두겠습니당.. 너무 길어졌네요ㅠㅠ
- 혱님과 얘기한 내용으로는 동행 추가 화면 -> 여행 제목 설정 화면 -> 다시 동행 추가 화면으로 돌아왔을 시 기존에 추가했던 동행자들이 남아있는가? 에 대해 그대로 남아 있는게 좋다고 하셨습니다!

[YB-98]: https://yeobee.atlassian.net/browse/YB-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ