### PR TITLE
[YB-118] 지출 리스트 api 적용

### DIFF
--- a/Projects/Entity/Sources/API/Expense/ExpenseItem.swift
+++ b/Projects/Entity/Sources/API/Expense/ExpenseItem.swift
@@ -9,19 +9,31 @@
 import Foundation
 
 public struct ExpenseItem: Codable, Equatable {
-    public var expenseType: ExpenseType
-    public var title: String
-    public var price: Int
-    public var currency: Currency
-    public var exchangedPrice: Int?
+    public var name: String
+    public var amount: Int
+    public var currency: String
+    public var koreanAmount: Int?
     public var category: ExpendCategory
 
-    public init(expenseType: ExpenseType, title: String, price: Int, currency: Currency, exchangedPrice: Int? = nil, category: ExpendCategory) {
-        self.expenseType = expenseType
-        self.title = title
-        self.price = price
+    enum CodingKeys: String, CodingKey {
+        case name
+        case amount
+        case currency = "currencyCode"
+        case koreanAmount
+        case category = "expenseCategoryImage"
+    }
+
+    public init(
+        name: String,
+        amount: Int,
+        currency: String,
+        koreanAmount: Int? = nil,
+        category: ExpendCategory
+    ) {
+        self.name = name
+        self.amount = amount
         self.currency = currency
-        self.exchangedPrice = exchangedPrice
+        self.koreanAmount = koreanAmount
         self.category = category
     }
 }
@@ -39,8 +51,14 @@ public extension Currency {
     static let cny: Currency = .init(suffix: " CNY", exchangeRate: 182.83)
 }
 
-public enum ExpendCategory: Codable {
-    case transition, eating, stay, travel, activity, shopping, air, etc
+public enum ExpendCategory: String, Codable, Equatable {
+    case transport = "TRANSPORT"
+    case food = "FOOD"
+    case lodge = "LODGE"
+    case travel = "TRAVEL"
+    case activity = "ACTIVITY"
+    case flight = "FLIGHT"
+    case shopping = "SHOPPING"
+    case etc = "ETC"
+    case income = "INCOME"
 }
-
-

--- a/Projects/Features/Expenditure/Sources/Domain/ExpendCategory.swift
+++ b/Projects/Features/Expenditure/Sources/Domain/ExpendCategory.swift
@@ -15,26 +15,28 @@ extension ExpendCategory {
     var image: Image {
         switch self {
         case .activity: return DesignSystemAsset.Icons.activity.swiftUIImage
-        case .air: return DesignSystemAsset.Icons.air.swiftUIImage
-        case .eating: return DesignSystemAsset.Icons.eating.swiftUIImage
+        case .flight: return DesignSystemAsset.Icons.air.swiftUIImage
+        case .food: return DesignSystemAsset.Icons.eating.swiftUIImage
         case .etc: return DesignSystemAsset.Icons.etc.swiftUIImage
         case .shopping: return DesignSystemAsset.Icons.shopping.swiftUIImage
-        case .stay: return DesignSystemAsset.Icons.stay.swiftUIImage
-        case .transition: return DesignSystemAsset.Icons.transition.swiftUIImage
+        case .lodge: return DesignSystemAsset.Icons.stay.swiftUIImage
+        case .transport: return DesignSystemAsset.Icons.transition.swiftUIImage
         case .travel: return DesignSystemAsset.Icons.travel.swiftUIImage
+        case .income: return DesignSystemAsset.Icons.travel.swiftUIImage
         }
     }
 
     var text: String {
         switch self {
         case .activity: return "액티비티"
-        case .air: return "항공"
-        case .eating: return "식비"
+        case .flight: return "항공"
+        case .food: return "식비"
         case .shopping: return "쇼핑"
-        case .stay: return "숙박"
-        case .transition: return "교통"
+        case .lodge: return "숙박"
+        case .transport: return "교통"
         case .travel: return "관광"
         case .etc: return "기타"
+        case .income: return "수입"
         }
     }
 }

--- a/Projects/Features/Expenditure/Sources/ExpenditureDetail/ExpenditureDetailView.swift
+++ b/Projects/Features/Expenditure/Sources/ExpenditureDetail/ExpenditureDetailView.swift
@@ -28,7 +28,7 @@ extension ExpenditureDetailView {
     var containerView: some View {
         WithViewStore(store, observe: \.expenseItem) { viewStore in
             VStack(spacing: 0) {
-                totalExpandPriceView(price: viewStore.price, convertedPrice: viewStore.price)
+                totalExpandPriceView(price: viewStore.amount, convertedPrice: viewStore.amount)
                     .padding(.all, 24)
                 Rectangle()
                     .frame(height: 10)
@@ -67,7 +67,7 @@ extension ExpenditureDetailView {
                     .foregroundColor(.ybColor(.gray5))
                     .font(.ybfont(.body1))
             }
-            if expenseItem.expenseType == .individualBudgetExpense {
+            if expenseItem.amount > 0 {
                 HStack {
                     Text("카테고리")
                         .foregroundColor(.ybColor(.gray6))
@@ -79,7 +79,7 @@ extension ExpenditureDetailView {
                 }
             }
             HStack {
-                Text(expenseItem.expenseType == .individualBudgetExpense ? "지출 항목" : "예산 내용")
+                Text(expenseItem.amount > 0 ? "지출 항목" : "예산 내용")
                     .foregroundColor(.ybColor(.gray6))
                     .font(.ybfont(.body1))
                 Spacer()

--- a/Projects/Features/Expenditure/Sources/ExpenditureDetail/ExpenditureDetailView.swift
+++ b/Projects/Features/Expenditure/Sources/ExpenditureDetail/ExpenditureDetailView.swift
@@ -28,7 +28,7 @@ extension ExpenditureDetailView {
     var containerView: some View {
         WithViewStore(store, observe: \.expenseItem) { viewStore in
             VStack(spacing: 0) {
-                totalExpandPriceView(price: viewStore.amount, convertedPrice: viewStore.amount)
+                totalExpandPriceView(price: viewStore.amount, convertedPrice: viewStore.koreanAmount)
                     .padding(.all, 24)
                 Rectangle()
                     .frame(height: 10)
@@ -41,17 +41,20 @@ extension ExpenditureDetailView {
         }
     }
 
-    func totalExpandPriceView(price: Int, convertedPrice: Int) -> some View {
+    func totalExpandPriceView(price: Int, convertedPrice: Int?) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("금액")
                 .foregroundColor(.ybColor(.gray6))
                 .font(.ybfont(.body3))
-            Text(price.formattedWithSeparator + " EUR")
+            Text(abs(price).formattedWithSeparator + " EUR")
                 .foregroundColor(.ybColor(.black))
                 .font(.ybfont(.header1))
-            Text("= " + convertedPrice.formattedWithSeparator + "원")
-                .foregroundColor(.ybColor(.gray4))
-                .font(.ybfont(.body2))
+            if let convertedPrice {
+                Text("= " + abs(convertedPrice).formattedWithSeparator + "원")
+                    .foregroundColor(.ybColor(.gray4))
+                    .font(.ybfont(.body2))
+            }
+
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -67,7 +70,7 @@ extension ExpenditureDetailView {
                     .foregroundColor(.ybColor(.gray5))
                     .font(.ybfont(.body1))
             }
-            if expenseItem.amount > 0 {
+            if expenseItem.amount < 0 {
                 HStack {
                     Text("카테고리")
                         .foregroundColor(.ybColor(.gray6))
@@ -79,7 +82,7 @@ extension ExpenditureDetailView {
                 }
             }
             HStack {
-                Text(expenseItem.amount > 0 ? "지출 항목" : "예산 내용")
+                Text(expenseItem.amount < 0 ? "지출 항목" : "예산 내용")
                     .foregroundColor(.ybColor(.gray6))
                     .font(.ybfont(.body1))
                 Spacer()

--- a/Projects/Features/Expenditure/Sources/ExpenditureList/ExpenditureListItem/ExpenditureListItemView.swift
+++ b/Projects/Features/Expenditure/Sources/ExpenditureList/ExpenditureListItem/ExpenditureListItemView.swift
@@ -66,7 +66,7 @@ extension ExpenditureListItemView {
                             HStack(spacing: 0) {
                                 Text(viewStore.price)
                                     .foregroundColor(
-                                        viewStore.expenseItem.amount > 0
+                                        viewStore.expenseItem.amount < 0
                                         ? .ybColor(.black)
                                         : .ybColor(.mainGreen)
                                     )
@@ -74,7 +74,7 @@ extension ExpenditureListItemView {
                                     .lineLimit(1)
                                 Text(viewStore.currency)
                                     .foregroundColor(
-                                        viewStore.expenseItem.amount > 0
+                                        viewStore.expenseItem.amount < 0
                                         ? .ybColor(.black)
                                         : .ybColor(.mainGreen)
                                     )

--- a/Projects/Features/Expenditure/Sources/ExpenditureList/ExpenditureListItem/ExpenditureListItemView.swift
+++ b/Projects/Features/Expenditure/Sources/ExpenditureList/ExpenditureListItem/ExpenditureListItemView.swift
@@ -26,18 +26,24 @@ extension ExpenditureListItemView {
     struct ViewState: Equatable {
         let expenseItem: ExpenseItem
         var exchangedPrice: Int? = nil
+        var currency: String
         var price: String {
-            return "+"
-            + " "
-            + expenseItem.price.formattedWithSeparator
+            let price =  expenseItem.amount
+            if price > 0 {
+                return "+ " + price.formattedWithSeparator
+            } else {
+                return "- " + abs(price).formattedWithSeparator
+            }
         }
-
 
         init(state: ExpenditureListItemReducer.State) {
             let expendseItem = state.expendseItem
             self.expenseItem = expendseItem
-            if expendseItem.currency.suffix != "원" {
-                self.exchangedPrice = Int(Double(expendseItem.price) * expendseItem.currency.exchangeRate)
+            self.currency = " \(state.expendseItem.currency)"
+            if expendseItem.currency != "KRW" {
+                self.exchangedPrice = expendseItem.koreanAmount
+            } else {
+                self.currency = "원"
             }
         }
     }
@@ -52,7 +58,7 @@ extension ExpenditureListItemView {
                         .frame(width: 41, height: 41)
                     VStack(alignment: .trailing, spacing: 4) {
                         HStack(alignment: .top, spacing: 9) {
-                            Text(viewStore.expenseItem.title)
+                            Text(viewStore.expenseItem.name)
                                 .foregroundColor(.ybColor(.black))
                                 .font(.ybfont(.body2))
                                 .lineLimit(1)
@@ -60,15 +66,15 @@ extension ExpenditureListItemView {
                             HStack(spacing: 0) {
                                 Text(viewStore.price)
                                     .foregroundColor(
-                                        viewStore.expenseItem.expenseType == .individualBudgetExpense
+                                        viewStore.expenseItem.amount > 0
                                         ? .ybColor(.black)
                                         : .ybColor(.mainGreen)
                                     )
                                     .font(.ybfont(.body2))
                                     .lineLimit(1)
-                                Text(viewStore.expenseItem.currency.suffix)
+                                Text(viewStore.currency)
                                     .foregroundColor(
-                                        viewStore.expenseItem.expenseType == .individualBudgetExpense
+                                        viewStore.expenseItem.amount > 0
                                         ? .ybColor(.black)
                                         : .ybColor(.mainGreen)
                                     )

--- a/Projects/Features/Expenditure/Sources/ExpenditureViewController/ExpenditureDetailViewController.swift
+++ b/Projects/Features/Expenditure/Sources/ExpenditureViewController/ExpenditureDetailViewController.swift
@@ -53,7 +53,7 @@ public final class ExpenditureDetailViewController: UIViewController {
     }
 
     func setupViews() {
-        title = "지출 상세"
+        title = expenseItem.amount > 0 ? "내 예산 상세" : "지출 상세"
         view.backgroundColor = .ybColor(.white)
     }
 

--- a/Projects/Features/Expenditure/Sources/ExpenditureViewController/ExpenditureDetailViewController.swift
+++ b/Projects/Features/Expenditure/Sources/ExpenditureViewController/ExpenditureDetailViewController.swift
@@ -53,7 +53,7 @@ public final class ExpenditureDetailViewController: UIViewController {
     }
 
     func setupViews() {
-        title = expenseItem.expenseType == .individualBudgetExpense ? "지출 상세" : "내 예산 상세"
+        title = "지출 상세"
         view.backgroundColor = .ybColor(.white)
     }
 

--- a/Projects/Features/Expenditure/Sources/ExpenditureViewController/ExpenditureViewController.swift
+++ b/Projects/Features/Expenditure/Sources/ExpenditureViewController/ExpenditureViewController.swift
@@ -27,12 +27,14 @@ public final class ExpenditureViewController: UIViewController {
 //    private let tripDateDataSource: TripDateDataSource
 
     public init(coordinator: ExpenditureCoordinator) {
-
         self.coordinator = coordinator
+
+        let startDate = Date()
+        let endDate = Calendar.current.date(byAdding: .day, value: 2, to: Date()) ?? Date()
         self.expenditureHostingController = ExpenditureHostingController(
             rootView: ExpenditureView(
                 store: .init(
-                    initialState: .init(type: .individual),
+                    initialState: .init(type: .individual, startDate: startDate, endDate: endDate),
                     reducer: {
                         ExpenditureReducer(cooridinator: coordinator)
                     }

--- a/Projects/Features/Expenditure/Sources/HostingController/ExpenditureReducer.swift
+++ b/Projects/Features/Expenditure/Sources/HostingController/ExpenditureReducer.swift
@@ -25,7 +25,7 @@ public struct ExpenditureReducer: Reducer {
         var startDate: Date
         var endDate: Date
         var beforeDate: Date
-        var isInitialShow: Bool = false
+        var isInitialShow: Bool = true
 
         init(type: ExpenditureTab, startDate: Date, endDate: Date) {
             self.type = type

--- a/Projects/Features/Expenditure/Sources/HostingController/ExpenditureReducer.swift
+++ b/Projects/Features/Expenditure/Sources/HostingController/ExpenditureReducer.swift
@@ -24,7 +24,9 @@ public struct ExpenditureReducer: Reducer {
 
         init(type: ExpenditureTab) {
             self.type = type
-            self.totalPrice = .init(type: type, isTappable: true
+            self.totalPrice = .init(
+                type: type,
+                isTappable: true
             )
         }
     }
@@ -45,18 +47,11 @@ public struct ExpenditureReducer: Reducer {
             case .tripDate(.tappedTripReadyButton):
                 return .send(.expenditureList(.setExpenditures([])))
             case let .tripDate(.tripDateItem(id: id, action: .tappedItem)):
-                let date = state.tripDate.tripDateItems[id: id]?.date
-                return .send(.expenditureList(.setExpenditures([
-                    .init(expenseType: .individualBudgetExpense, title: "8글자까지보이기안보이면어떡하징", price: 100051353216, currency: .usd, category: .activity),
-                    .init(expenseType: .individualBudgetExpense, title: "파스타", price: 5000, currency: .krw, category: .activity),
-                    .init(expenseType: .individualBudgetExpense, title: "저는 이번주에 일본갑니다", price: 54800, currency: .jpy, category: .air),
-                    .init(expenseType: .individualBudgetExpense, title: "부럽죠", price: 6421, currency: .jpy, category: .etc),
-                    .init(expenseType: .individualBudgetExpense, title: "여러분 선물 사올게요", price: 558588422, currency: .eur, category: .eating),
-                    .init(expenseType: .individualBudgetExpense, title: "꺄아아아ㅏㅇ", price: 123123, currency: .usd, category: .transition),
-                    .init(expenseType: .individualBudgetExpense, title: "8글자까지보이기안보이면어떡하징", price: 7000, currency: .krw, category: .travel),
-                    .init(expenseType: .individualBudgetExpense, title: "태태제리제로화이팅", price: 100, currency: .jpy, category: .stay),
-                    .init(expenseType: .individualBudgetExpense, title: "여비팀화이팅", price: 87000, currency: .eur, category: .etc),
-                ])))
+                guard let tripDate = state.tripDate.tripDateItems[id: id]?.date else { return .none }
+                return .run { send in
+                    let expenseItems = try await expenseUseCase.getExpenseList(1, tripDate)
+                    await send(.expenditureList(.setExpenditures(expenseItems)))
+                }
             case .tappedAddButton:
                 cooridinator.expenditureEdit()
                 return .none
@@ -64,10 +59,7 @@ public struct ExpenditureReducer: Reducer {
                 cooridinator.totalExpenditureList()
                 return .none
             case .tappedFilterButton:
-                return .run { _ in
-                    let result = try await expenseUseCase.getExpenseList("냠냠")
-                    print(result)
-                }
+                return .none
             case let .expenditureList(.expenditureListItem(id: _, action: .tappedExpenditureItem(expenseItem))):
                 cooridinator.expenditureDetail(expenseItem: expenseItem)
                 return .none

--- a/Projects/Features/Expenditure/Sources/HostingController/ExpenditureReducer.swift
+++ b/Projects/Features/Expenditure/Sources/HostingController/ExpenditureReducer.swift
@@ -59,12 +59,17 @@ public struct ExpenditureReducer: Reducer {
                 let currentDate = Date()
                 if state.isInitialShow {
                     state.isInitialShow = false
+                    let selectDate: Date
                     if currentDate < state.startDate {
-                        return .send(.getExpenditure(state.beforeDate))
+                        selectDate = state.beforeDate
                     } else if currentDate > state.endDate {
-                        return .send(.getExpenditure(state.startDate))
+                        selectDate = state.startDate
                     } else {
-                        return .send(.getExpenditure(currentDate))
+                        selectDate = currentDate
+                    }
+                    return .run { send in
+                        await send(.tripDate(.selectDate(selectDate)))
+                        await send(.getExpenditure(selectDate))
                     }
                 } else {
                     return .none

--- a/Projects/Features/Expenditure/Sources/HostingController/ExpenditureView.swift
+++ b/Projects/Features/Expenditure/Sources/HostingController/ExpenditureView.swift
@@ -37,6 +37,7 @@ struct ExpenditureView: View {
                 addButtonView
             }
         }
+        .onAppear { store.send(.onAppear) }
     }
 }
 

--- a/Projects/Features/Expenditure/Sources/SharedExpenditure/SharedExpenditureReducer.swift
+++ b/Projects/Features/Expenditure/Sources/SharedExpenditure/SharedExpenditureReducer.swift
@@ -5,7 +5,7 @@
 //  Created Hoyoung Lee on 12/30/23.
 //  Copyright © 2023 YeoBee.com. All rights reserved.
 
-import Combine
+import Foundation
 import ComposableArchitecture
 
 public enum ExpenditureTab: Equatable {
@@ -17,8 +17,8 @@ public struct SharedExpenditureReducer: Reducer {
 
     public struct State: Equatable {
         @BindingState var selectedTab: ExpenditureTab = .shared
-        var sharedExpenditure = ExpenditureReducer.State(type: .shared)
-        var individualExpenditure = ExpenditureReducer.State(type: .individual)
+        var sharedExpenditure = ExpenditureReducer.State(type: .shared, startDate: Date(), endDate: Date())
+        var individualExpenditure = ExpenditureReducer.State(type: .individual, startDate: Date(), endDate: Date())
     }
 
     public enum Action: BindableAction {

--- a/Projects/Features/Expenditure/Sources/TripDate/TripDateReducer.swift
+++ b/Projects/Features/Expenditure/Sources/TripDate/TripDateReducer.swift
@@ -12,12 +12,14 @@ public struct TripDateReducer: Reducer {
     public struct State: Equatable {
         var tripDateItems: IdentifiedArrayOf<TripDateItemReducer.State> = []
         var dates: [Date] = []
+        var readyDate: Date
         var selectedDate: Date?
 
         init() {
-            let date = Date()
-            let startDate = date
-            let endDate = Calendar.current.date(byAdding: .day, value: 10, to: date)
+            let date = Calendar.current.date(byAdding: .day, value: -1, to: Date())
+            let startDate = date ?? Date()
+            let endDate = Calendar.current.date(byAdding: .day, value: 2, to: startDate)
+            readyDate = Calendar.current.date(byAdding: .day, value: -1, to: startDate) ?? Date()
             let dates = datesBetween(startDate: startDate, endDate: endDate)
             self.dates = dates
             dates.enumerated().forEach { index, date in

--- a/Projects/Features/Expenditure/Sources/TripDate/TripDateReducer.swift
+++ b/Projects/Features/Expenditure/Sources/TripDate/TripDateReducer.swift
@@ -45,7 +45,16 @@ public struct TripDateReducer: Reducer {
                 state.selectedDate = selectedDate
                 state.tripDateItems.removeAll()
                 state.dates.forEach { date in
-                    state.tripDateItems.updateOrAppend(.init(isSelected: date == selectedDate, date: date))
+                    if let selectedDate {
+                        let convertedDate = payedAtDateFormatter.string(from: date)
+                        let convertedSelectedDate = payedAtDateFormatter.string(from: selectedDate)
+                        state.tripDateItems.updateOrAppend(.init(
+                            isSelected: convertedDate == convertedSelectedDate,
+                            date: date
+                        ))
+                    } else {
+                        state.tripDateItems.updateOrAppend(.init(isSelected: false, date: date))
+                    }
                 }
                 return .none
             }
@@ -53,6 +62,12 @@ public struct TripDateReducer: Reducer {
         .forEach(\.tripDateItems, action: /Action.tripDateItem) {
             TripDateItemReducer()
         }
+    }
+
+    var payedAtDateFormatter: DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "YYYY-MM-dd"
+        return dateFormatter
     }
 }
 

--- a/Projects/Features/Expenditure/Sources/TripDate/TripDateReducer.swift
+++ b/Projects/Features/Expenditure/Sources/TripDate/TripDateReducer.swift
@@ -15,9 +15,7 @@ public struct TripDateReducer: Reducer {
         var readyDate: Date
         var selectedDate: Date?
 
-        init() {
-            let date = Calendar.current.date(byAdding: .day, value: -1, to: Date())
-            let startDate = date ?? Date()
+        init(startDate: Date, endDate: Date) {
             let endDate = Calendar.current.date(byAdding: .day, value: 2, to: startDate)
             readyDate = Calendar.current.date(byAdding: .day, value: -1, to: startDate) ?? Date()
             let dates = datesBetween(startDate: startDate, endDate: endDate)

--- a/Projects/Features/Expenditure/Sources/TripDate/TripDateReducer.swift
+++ b/Projects/Features/Expenditure/Sources/TripDate/TripDateReducer.swift
@@ -29,6 +29,7 @@ public struct TripDateReducer: Reducer {
     public enum Action {
         case tripDateItem(id: TripDateItemReducer.State.ID, action: TripDateItemReducer.Action)
         case tappedTripReadyButton
+        case selectDate(Date?)
     }
 
     public var body: some ReducerOf<TripDateReducer> {
@@ -36,17 +37,15 @@ public struct TripDateReducer: Reducer {
             switch action {
             case let .tripDateItem(id: id, action: .tappedItem):
                 let selectedDate = state.tripDateItems[id: id]?.date
+                return .send(.selectDate(selectedDate))
+            case .tappedTripReadyButton:
+                return .send(.selectDate(nil))
+
+            case let .selectDate(selectedDate):
                 state.selectedDate = selectedDate
                 state.tripDateItems.removeAll()
                 state.dates.forEach { date in
                     state.tripDateItems.updateOrAppend(.init(isSelected: date == selectedDate, date: date))
-                }
-                return .none
-            case .tappedTripReadyButton:
-                state.selectedDate = nil
-                state.tripDateItems.removeAll()
-                state.dates.forEach { date in
-                    state.tripDateItems.updateOrAppend(.init(isSelected: false, date: date))
                 }
                 return .none
             }

--- a/Projects/Repository/Sources/DTO/YBBaseReponse.swift
+++ b/Projects/Repository/Sources/DTO/YBBaseReponse.swift
@@ -1,0 +1,21 @@
+//
+//  YBBaseReponse.swift
+//  Repository
+//
+//  Created by Hoyoung Lee on 2/11/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import Foundation
+
+public struct YBBaseReponse<T: Codable>: Codable {
+    public var content: T
+    public var pageable: PageableResponse
+    public var totalPages: Int
+    public var last: Bool
+}
+
+public struct PageableResponse: Codable {
+    public var pageNumber: Int
+    public var pageSize: Int
+}

--- a/Projects/Repository/Sources/ExpenseRepository.swift
+++ b/Projects/Repository/Sources/ExpenseRepository.swift
@@ -20,7 +20,7 @@ final public class ExpenseRepository: ExpenseRepositoryInterface {
 
     public init() {}
 
-    let provider = MoyaProvider<ExpenseService>()
+    let provider = MoyaProvider<ExpenseService>(plugins: [NetworkLogger()])
 
     public func getExpenseList(request: FetchExpenseListRequest) async throws -> FetchExpenseListResponse {
          let result = await provider.request(

--- a/Projects/UseCase/Sources/ExpenseUseCase.swift
+++ b/Projects/UseCase/Sources/ExpenseUseCase.swift
@@ -13,7 +13,7 @@ import Entity
 import ComposableArchitecture
 
 public struct ExpenseUseCase {
-    public var getExpenseList: @Sendable (_ tripId: String) async throws -> String
+    public var getExpenseList: @Sendable (_ tripId: Int, _ date: Date) async throws -> [ExpenseItem]
 }
 
 extension ExpenseUseCase: TestDependencyKey {
@@ -31,9 +31,16 @@ extension ExpenseUseCase {
     public static func live(
         expenseRepository: ExpenseRepositoryInterface
     ) -> Self {
-        return .init(getExpenseList: { tripId in
-//            let data = try await expenseRepository.getExpenseList(request: .init(tripId: 0, pageIndex: 0, pageSize: 0))
-            return "냠냠"
+        return .init(getExpenseList: { tripId, date in
+            let data = try await expenseRepository.getExpenseList(
+                request: .init(
+                    tripId: tripId,
+                    pageIndex: 0,
+                    pageSize: 30,
+                    date: date
+                )
+            )
+            return data.content
         })
     }
 }

--- a/Projects/YBNetwork/Sources/Service/ExpenseService.swift
+++ b/Projects/YBNetwork/Sources/Service/ExpenseService.swift
@@ -30,11 +30,11 @@ extension ExpenseService: TargetType {
     public var path: String {
         switch self {
         case .fetchList:
-            return "/v1/expense/list"
+            return "/v1/expenses"
             //        case .fetchDetail:
             //            return "v1/expense"
-                    case .create:
-                        return "v1/expense"
+        case .create:
+            return "v1/expenses"
             //        case .delete:
             //            return "v1/expense"
         }
@@ -62,7 +62,7 @@ extension ExpenseService: TargetType {
                 "pageSize": pageSize
             ]
             if let type { params["type"] = type }
-            if let date { params["date"] = ISO8601DateFormatter().string(from: date) }
+            if let date { params["payedAt"] = payedAtDateFormatter.string(from: date) }
             if let method { params["method"] = method }
             if let unitId { params["unitId"] = unitId }
             return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
@@ -76,6 +76,13 @@ extension ExpenseService: TargetType {
     }
     
     public var headers: [String: String]? {
-        return ["Content-type": "application/json"]
+        return ["Content-type": "application/json",
+                "Authorization": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwiZXhwIjoxNzA4MTg2MTA5fQ.CXKRiLdVMTxwOAQGYC0m1KLeAEup9sn-z-v5ttAo_BI"]
+    }
+
+    var payedAtDateFormatter: DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "YYYY-MM-dd"
+        return dateFormatter
     }
 }

--- a/Projects/YeoBee/Sources/Coordinator/RootCoordinator.swift
+++ b/Projects/YeoBee/Sources/Coordinator/RootCoordinator.swift
@@ -24,9 +24,9 @@ final class RootCoordinator: NSObject, Coordinator, ParentCoordinator {
     func start(animated: Bool) {
         /// 토큰 처리
 //        if true {
-        sign(navigationController: navigationController)
+//        sign(navigationController: navigationController)
 //        } else {
-//            home(navigationController: navigationController)
+            home(navigationController: navigationController)
 //        }
 //        home(navigationController: navigationController)
     }


### PR DESCRIPTION
## 이슈번호
[YB-118]

## 수정 사항
- 날짜별 지출 목록 리스트 api를 적용하였습니다
- 가계부 켰을때 나타내는 날짜 로직도 적용했습니다
- DTO가 변경되면서 자잘한 View 로직도 수정했습니다

## 화면 (Optional)
| scene name |
| --- |
| ![RPReplay_Final1707641417](https://github.com/YAPP-Github/YeoBee-iOS/assets/40068674/2f9bcaa3-c327-4004-989e-0f4d0131c20f) |

## target module
YeoBee

## 참고사항


[YB-118]: https://yeobee.atlassian.net/browse/YB-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ