### PR TITLE
[YB-127] 더보기 화면 무한 스크롤 구현 & 홈 화면 일부 기능 추가

### DIFF
--- a/Projects/DesignSystem/Sources/Toast/ToastPresentationController.swift
+++ b/Projects/DesignSystem/Sources/Toast/ToastPresentationController.swift
@@ -23,7 +23,7 @@ public class Toast {
         icon: ToastIcon,
         _ text: String
     ) -> Toast {
-        let view = ToastView(child: YBToastView(icon: .warning, text))
+        let view = ToastView(child: YBToastView(icon: icon, text))
         return self.init(view: view)
     }
 

--- a/Projects/Entity/Sources/API/Pageable.swift
+++ b/Projects/Entity/Sources/API/Pageable.swift
@@ -10,10 +10,10 @@ import Foundation
 
 // 페이지 정보
 public struct Pageable: Codable {
-    var pageNumber: Int
-    var pageSize: Int
-    var sort: SortType
-    var offset: Int
-    var paged: Bool
-    var unpaged: Bool
+    public var pageNumber: Int
+    public var pageSize: Int
+    public var sort: SortType
+    public var offset: Int
+    public var paged: Bool
+    public var unpaged: Bool
 }

--- a/Projects/Features/Home/Sources/Coordinator/HomeCoordinator.swift
+++ b/Projects/Features/Home/Sources/Coordinator/HomeCoordinator.swift
@@ -13,10 +13,15 @@ import Entity
 import TravelRegistration
 import Trip
 
+public protocol HomeCoordinatorDelegate: AnyObject {
+    func finishedRegistration()
+}
+
 final public class HomeCoordinator: HomeCoordinatorInterface {
     public var navigationController: UINavigationController
     public var viewControllerRef: UIViewController?
     public var childCoordinators = [Coordinator]()
+    public weak var delegate: HomeCoordinatorDelegate?
 
     public init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -30,9 +35,9 @@ final public class HomeCoordinator: HomeCoordinatorInterface {
 }
 
 extension HomeCoordinator {
-
     public func travelRegisteration() {
         let countryCoordinator = TravelRegistrationCoordinator(navigationController: navigationController)
+        countryCoordinator.delegate = self
         countryCoordinator.parent = self
         addChild(countryCoordinator)
         countryCoordinator.start(animated: true)
@@ -43,5 +48,11 @@ extension HomeCoordinator {
         tripCoordinator.parent = self
         addChild(tripCoordinator)
         tripCoordinator.start(animated: true)
+    }
+}
+
+extension HomeCoordinator: TravelRegistrationCoordinatorDelegate {
+    public func finishedRegistration() {
+        delegate?.finishedRegistration()
     }
 }

--- a/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
+++ b/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
@@ -102,4 +102,28 @@ public final class HomeReactor: Reactor {
             self.action.onNext(.comingTrip(tripItems))
         }
     }
+    
+    func updateHomeTripUseCase() {
+        self.action.onNext(.passedTrip([]))
+        self.action.onNext(.travelingTrip([]))
+        self.action.onNext(.comingTrip([]))
+        
+        Task {
+            let pastResult = try await tripUseCase.getPastTrip(0, 3)
+            let tripItems = pastResult.content
+            self.action.onNext(.passedTrip(tripItems))
+        }
+        
+        Task {
+            let presentResult = try await tripUseCase.getPresentTrip(0, 3)
+            let tripItems = presentResult.content
+            self.action.onNext(.travelingTrip(tripItems))
+        }
+        
+        Task {
+            let futureResult = try await tripUseCase.getFutureTrip(0, 3)
+            let tripItems = futureResult.content
+            self.action.onNext(.comingTrip(tripItems))
+        }
+    }
 }

--- a/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
+++ b/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
@@ -102,28 +102,4 @@ public final class HomeReactor: Reactor {
             self.action.onNext(.comingTrip(tripItems))
         }
     }
-    
-    func updateHomeTripUseCase() {
-        self.action.onNext(.passedTrip([]))
-        self.action.onNext(.travelingTrip([]))
-        self.action.onNext(.comingTrip([]))
-        
-        Task {
-            let pastResult = try await tripUseCase.getPastTrip(0, 3)
-            let tripItems = pastResult.content
-            self.action.onNext(.passedTrip(tripItems))
-        }
-        
-        Task {
-            let presentResult = try await tripUseCase.getPresentTrip(0, 3)
-            let tripItems = presentResult.content
-            self.action.onNext(.travelingTrip(tripItems))
-        }
-        
-        Task {
-            let futureResult = try await tripUseCase.getFutureTrip(0, 3)
-            let tripItems = futureResult.content
-            self.action.onNext(.comingTrip(tripItems))
-        }
-    }
 }

--- a/Projects/Features/Home/Sources/Presentation/Reactor /MoreTripReactor.swift
+++ b/Projects/Features/Home/Sources/Presentation/Reactor /MoreTripReactor.swift
@@ -76,31 +76,33 @@ public final class MoreTripReactor: Reactor {
         return newState
     }
     
+    private func handleTripResponse(result: TripResponse, pageNumber: Int) {
+        var currentTripItems = currentState.trips
+        currentTripItems.append(contentsOf: result.content)
+        action.onNext(.trips(currentTripItems))
+        action.onNext(.pageNumber(pageNumber))
+        action.onNext(.isLoading(false))
+    }
+    
     func moreTripUseCase() {
         switch currentState.tripType {
         case .traveling:
             Task {
                 let presentResult = try await tripUseCase.getPresentTrip(0, 5)
-                let tripItems = presentResult.content
-                action.onNext(.trips(tripItems))
                 action.onNext(.totalPage(presentResult.totalPages))
-                action.onNext(.pageNumber(presentResult.pageable.pageNumber))
+                handleTripResponse(result: presentResult, pageNumber: presentResult.pageable.pageNumber)
             }
         case .coming:
             Task {
                 let futureResult = try await tripUseCase.getFutureTrip(0, 5)
-                let tripItems = futureResult.content
-                action.onNext(.trips(tripItems))
                 action.onNext(.totalPage(futureResult.totalPages))
-                action.onNext(.pageNumber(futureResult.pageable.pageNumber))
+                handleTripResponse(result: futureResult, pageNumber: futureResult.pageable.pageNumber)
             }
         case .passed:
             Task {
                 let pastResult = try await tripUseCase.getPastTrip(0, 5)
-                let tripItems = pastResult.content
-                action.onNext(.trips(tripItems))
                 action.onNext(.totalPage(pastResult.totalPages))
-                action.onNext(.pageNumber(pastResult.pageable.pageNumber))
+                handleTripResponse(result: pastResult, pageNumber: pastResult.pageable.pageNumber)
             }
         }
     }
@@ -119,32 +121,17 @@ public final class MoreTripReactor: Reactor {
         case .traveling:
             Task {
                 let presentResult = try await tripUseCase.getPresentTrip(pageNumber, 5)
-                var currentTripItems = currentState.trips
-                let newTripItems = presentResult.content
-                currentTripItems.append(contentsOf: newTripItems)
-                self.action.onNext(.trips(currentTripItems))
-                self.action.onNext(.pageNumber(presentResult.pageable.pageNumber))
-                self.action.onNext(.isLoading(false))
+                handleTripResponse(result: presentResult, pageNumber: presentResult.pageable.pageNumber)
             }
         case .coming:
             Task {
                 let futureResult = try await tripUseCase.getFutureTrip(pageNumber, 5)
-                var currentTripItems = currentState.trips
-                let newTripItems = futureResult.content
-                currentTripItems.append(contentsOf: newTripItems)
-                self.action.onNext(.trips(currentTripItems))
-                self.action.onNext(.pageNumber(futureResult.pageable.pageNumber))
-                self.action.onNext(.isLoading(false))
+                handleTripResponse(result: futureResult, pageNumber: futureResult.pageable.pageNumber)
             }
         case .passed:
             Task {
                 let pastResult = try await tripUseCase.getPastTrip(pageNumber, 5)
-                var currentTripItems = currentState.trips
-                let newTripItems = pastResult.content
-                currentTripItems.append(contentsOf: newTripItems)
-                self.action.onNext(.trips(currentTripItems))
-                self.action.onNext(.pageNumber(pastResult.pageable.pageNumber))
-                self.action.onNext(.isLoading(false))
+                handleTripResponse(result: pastResult, pageNumber: pastResult.pageable.pageNumber)
             }
         }
     }

--- a/Projects/Features/Home/Sources/Presentation/Reactor /MoreTripReactor.swift
+++ b/Projects/Features/Home/Sources/Presentation/Reactor /MoreTripReactor.swift
@@ -17,15 +17,24 @@ public final class MoreTripReactor: Reactor {
     
     public enum Action {
         case trips([TripItem])
+        case totalPage(Int)
+        case pageNumber(Int)
+        case isLoading(Bool)
     }
     
     public enum Mutation {
         case trips([TripItem])
+        case totalPage(Int)
+        case pageNumber(Int)
+        case isLoading(Bool)
     }
     
     public struct State {
         var trips: [TripItem] = []
         var tripType: TripType
+        var totalPage: Int = 0
+        var pageNumber: Int = 0
+        var isLoading: Bool = false
     }
     
     @Dependency(\.tripUseCase) var tripUseCase
@@ -40,6 +49,12 @@ public final class MoreTripReactor: Reactor {
         switch action {
         case .trips(let trips):
             return .just(.trips(trips))
+        case .totalPage(let totalPage):
+            return .just(.totalPage(totalPage))
+        case .pageNumber(let pageNumber):
+            return .just(.pageNumber(pageNumber))
+        case .isLoading(let isLoading):
+            return .just(.isLoading(isLoading))
         }
     }
     
@@ -50,6 +65,12 @@ public final class MoreTripReactor: Reactor {
         switch mutation {
         case .trips(let trips):
             newState.trips = trips
+        case .totalPage(let totalPage):
+            newState.totalPage = totalPage
+        case .pageNumber(let pageNumber):
+            newState.pageNumber = pageNumber
+        case .isLoading(let isLoading):
+            newState.isLoading = isLoading
         }
         
         return newState
@@ -59,21 +80,71 @@ public final class MoreTripReactor: Reactor {
         switch currentState.tripType {
         case .traveling:
             Task {
-                let presentResult = try await tripUseCase.getPresentTrip(0, 10)
+                let presentResult = try await tripUseCase.getPresentTrip(0, 5)
                 let tripItems = presentResult.content
-                self.action.onNext(.trips(tripItems))
+                action.onNext(.trips(tripItems))
+                action.onNext(.totalPage(presentResult.totalPages))
+                action.onNext(.pageNumber(presentResult.pageable.pageNumber))
             }
         case .coming:
             Task {
-                let futureResult = try await tripUseCase.getFutureTrip(0, 10)
+                let futureResult = try await tripUseCase.getFutureTrip(0, 5)
                 let tripItems = futureResult.content
-                self.action.onNext(.trips(tripItems))
+                action.onNext(.trips(tripItems))
+                action.onNext(.totalPage(futureResult.totalPages))
+                action.onNext(.pageNumber(futureResult.pageable.pageNumber))
             }
         case .passed:
             Task {
-                let pastResult = try await tripUseCase.getPastTrip(0, 10)
+                let pastResult = try await tripUseCase.getPastTrip(0, 5)
                 let tripItems = pastResult.content
-                self.action.onNext(.trips(tripItems))
+                action.onNext(.trips(tripItems))
+                action.onNext(.totalPage(pastResult.totalPages))
+                action.onNext(.pageNumber(pastResult.pageable.pageNumber))
+            }
+        }
+    }
+    
+    func loadNextPageIfNeeded() {
+        if !currentState.isLoading && currentState.pageNumber < currentState.totalPage {
+            self.action.onNext(.isLoading(true))
+            updateMoreTripUseCase(pageNumber: currentState.pageNumber + 1)
+        }
+    }
+
+    private func updateMoreTripUseCase(pageNumber: Int) {
+        self.action.onNext(.pageNumber(pageNumber))
+        
+        switch currentState.tripType {
+        case .traveling:
+            Task {
+                let presentResult = try await tripUseCase.getPresentTrip(pageNumber, 5)
+                var currentTripItems = currentState.trips
+                let newTripItems = presentResult.content
+                currentTripItems.append(contentsOf: newTripItems)
+                self.action.onNext(.trips(currentTripItems))
+                self.action.onNext(.pageNumber(presentResult.pageable.pageNumber))
+                self.action.onNext(.isLoading(false))
+            }
+        case .coming:
+            Task {
+                let futureResult = try await tripUseCase.getFutureTrip(pageNumber, 5)
+                var currentTripItems = currentState.trips
+                let newTripItems = futureResult.content
+                currentTripItems.append(contentsOf: newTripItems)
+                self.action.onNext(.trips(currentTripItems))
+                self.action.onNext(.pageNumber(futureResult.pageable.pageNumber))
+                self.action.onNext(.isLoading(false))
+            }
+        case .passed:
+            Task {
+                let pastResult = try await tripUseCase.getPastTrip(pageNumber, 5)
+                var currentTripItems = currentState.trips
+                let newTripItems = pastResult.content
+                currentTripItems.append(contentsOf: newTripItems)
+                self.action.onNext(.trips(currentTripItems))
+                self.action.onNext(.pageNumber(pastResult.pageable.pageNumber))
+                self.action.onNext(.isLoading(false))
             }
         }
     }

--- a/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
@@ -35,6 +35,10 @@ public final class HomeViewController: UIViewController {
     private var dataSource: UICollectionViewDiffableDataSource<HomeSection, HomeDataItem>?
     private var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeDataItem>()
     public var coordinator: HomeCoordinator?
+    private let dateFormatter: DateFormatter = {
+        $0.dateFormat = "yyyy-MM-dd"
+        return $0
+    }(DateFormatter())
 
     // MARK: - Properties
     lazy var homeCollectionView = HomeCollectionView()
@@ -145,11 +149,22 @@ public final class HomeViewController: UIViewController {
                         header.moreButton.isHidden = false
                     }
                 } else if indexPath.section == self.snapshot.indexOfSection(.coming) {
-                    // [TODO] 다가오는 가장 빠른 여행 출발일 기준 D-day로 설정
-//                    let items = snapshot.itemIdentifiers(inSection: .coming)
-                    header.sectionTitleLabel.text = TripType.coming.rawValue
-                    if self.reactor.currentState.comingTrip.count > 1 {
-                        header.moreButton.isHidden = false
+                    let items = snapshot.itemIdentifiers(inSection: .coming)
+                    if let item = items.first {
+                        switch item {
+                        case .header, .traveling, .passed:
+                            break
+                        case .coming(let tripItem):
+                            // 현재 날짜와 startDate 차이 계산
+                            if let startDate = dateFormatter.date(from: tripItem.startDate) {
+                                if let daysDiff = Calendar.current.dateComponents([.day], from: Date(), to: startDate).day {
+                                    header.sectionTitleLabel.text = "\(TripType.coming.rawValue), D-\(daysDiff)"
+                                    if self.reactor.currentState.comingTrip.count > 1 {
+                                        header.moreButton.isHidden = false
+                                    }
+                                }
+                            }
+                        }
                     }
                 } else if indexPath.section == self.snapshot.indexOfSection(.passed) {
                     header.sectionTitleLabel.text = TripType.passed.rawValue

--- a/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
@@ -302,12 +302,15 @@ extension HomeViewController: HomeCollectionHeaderViewCellDelegate {
 // MARK: - 더보기
 extension HomeViewController: HomeSectionHeaderViewDelegate {
     func moreButtonTapped(tripType: String) {
-        TripType.allCases.forEach {
-            if $0.rawValue.first == tripType.first {
-                let moreTripReactor = MoreTripReactor(tripType: $0)
-                let moreTripViewController = MoreTripViewController(coordinator: coordinator!, reactor: moreTripReactor)
-                self.navigationController?.isNavigationBarHidden = false
-                self.navigationController?.pushViewController(moreTripViewController, animated: true)
+        TripType.allCases.forEach { tripTypeCase in
+            if let coordinator = coordinator,
+               let firstCharacter = tripType.first,
+               tripTypeCase.rawValue.first == firstCharacter {
+                
+                let moreTripReactor = MoreTripReactor(tripType: tripTypeCase)
+                let moreTripViewController = MoreTripViewController(coordinator: coordinator, reactor: moreTripReactor)
+                navigationController?.isNavigationBarHidden = false
+                navigationController?.pushViewController(moreTripViewController, animated: true)
             }
         }
     }

--- a/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
@@ -207,6 +207,7 @@ public final class HomeViewController: UIViewController {
     
     private func setCollectionViewDelegate() {
         homeCollectionView.delegate = self
+        coordinator?.delegate = self
     }
 }
 
@@ -308,6 +309,17 @@ extension HomeViewController: HomeSectionHeaderViewDelegate {
                 self.navigationController?.isNavigationBarHidden = false
                 self.navigationController?.pushViewController(moreTripViewController, animated: true)
             }
+        }
+    }
+}
+
+// MARK: - 여행 등록 완료 후
+extension HomeViewController: HomeCoordinatorDelegate {
+    public func finishedRegistration() {
+        reactor.updateHomeTripUseCase()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let toast = Toast.text(icon: .complete, "새로운 여행이 등록 되었어요!")
+            toast.show()
         }
     }
 }

--- a/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
@@ -303,7 +303,7 @@ extension HomeViewController: HomeCollectionHeaderViewCellDelegate {
 extension HomeViewController: HomeSectionHeaderViewDelegate {
     func moreButtonTapped(tripType: String) {
         TripType.allCases.forEach {
-            if $0.rawValue == tripType {
+            if $0.rawValue.first == tripType.first {
                 let moreTripReactor = MoreTripReactor(tripType: $0)
                 let moreTripViewController = MoreTripViewController(coordinator: coordinator!, reactor: moreTripReactor)
                 self.navigationController?.isNavigationBarHidden = false

--- a/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
@@ -319,7 +319,7 @@ extension HomeViewController: HomeSectionHeaderViewDelegate {
 // MARK: - 여행 등록 완료 후
 extension HomeViewController: HomeCoordinatorDelegate {
     public func finishedRegistration() {
-        reactor.updateHomeTripUseCase()
+        reactor.homeTripUseCase()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             let toast = Toast.text(icon: .complete, "새로운 여행이 등록 되었어요!")
             toast.show()

--- a/Projects/Features/Home/Sources/Presentation/ViewController/MoreTripViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/MoreTripViewController.swift
@@ -121,6 +121,17 @@ extension MoreTripViewController: UICollectionViewDelegate {
         let tripItem = reactor.currentState.trips[indexPath.row]
         coordinator.trip(tripItem: tripItem)
     }
+    
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let height = scrollView.frame.height // 스크롤뷰의 전체 높이
+        let contentSizeHeight = scrollView.contentSize.height // 전체 콘텐츠 영역의 높이
+        let offset = scrollView.contentOffset.y // 클릭 위치
+        let reachedBottom = (offset > contentSizeHeight - height) // (클릭 지점 + 스크롤뷰 높이 == 전체 컨텐츠 높이) -> Bool
+        
+        if reachedBottom && (contentSizeHeight > height) { // 스크롤이 바닥에 닿았다면 & 컨텐츠가 스크롤 가능한 높이일 때
+            reactor.loadNextPageIfNeeded()
+        }
+    }
 }
 
 // MARK: - Bind

--- a/Projects/Features/TravelRegistration/Sources/Coordinator/TravelRegistrationCoordinator.swift
+++ b/Projects/Features/TravelRegistration/Sources/Coordinator/TravelRegistrationCoordinator.swift
@@ -11,12 +11,17 @@ import UIKit
 import Coordinator
 import Entity
 
+public protocol TravelRegistrationCoordinatorDelegate: AnyObject {
+    func finishedRegistration()
+}
+
 final public class TravelRegistrationCoordinator: TravelRegistrationCoordinatorInterface {
     public var navigationController: UINavigationController
     public var travelRegistrationNavigationController: UINavigationController?
     public var viewControllerRef: UIViewController?
     public var childCoordinators = [Coordinator]()
     public var parent: HomeCoordinatorInterface?
+    public weak var delegate: TravelRegistrationCoordinatorDelegate?
 
     public init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -35,6 +40,11 @@ final public class TravelRegistrationCoordinator: TravelRegistrationCoordinatorI
     public func coordinatorDidFinish() {
         travelRegistrationNavigationController = nil
         parent?.childDidFinish(self)
+    }
+    
+    public func finishedRegistration() {
+        delegate?.finishedRegistration()
+        coordinatorDidFinish()
     }
 
     deinit {

--- a/Projects/Features/TravelRegistration/Sources/Presentation/TravelTitle/TravelTitleViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/TravelTitle/TravelTitleViewController.swift
@@ -159,7 +159,7 @@ extension TravelTitleViewController: View {
             .bind { [weak self] isSuccess in
                 if isSuccess {
                     self?.navigationController?.dismiss(animated: true)
-                    self?.coordinator.coordinatorDidFinish()
+                    self?.coordinator.finishedRegistration()
                 } else {
                     print("post 실패")
                 }


### PR DESCRIPTION
## 이슈번호
[YB-127]


## 수정 사항
- 더보기 화면 무한스크롤 구현했습니다. 스크롤 시 5개씩 로드되는데 테스트하면서 변경해도 좋을 것 같아요!
- 홈 다가오는 여행에 제일 첫 여행의 startDate 기준으로 D-day 설정했습니다.
- 여행 등록 완료 후에 api 재요청과 Toast 띄우도록 구현했습니다.


## 화면 (Optional)
<img width="386" alt="스크린샷 2024-02-16 오전 12 01 02" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/de3d493c-19ec-4cd7-9735-7b6ea5107a2d">


## target module
- Home

## 참고사항


[YB-127]: https://yeobee.atlassian.net/browse/YB-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ