### PR TITLE
[YB-130] Alert 적용 & 여행 삭제 & 데이터 갱신 처리 구현

### DIFF
--- a/Projects/DesignSystem/Sources/Popup/PopupPresentationController.swift
+++ b/Projects/DesignSystem/Sources/Popup/PopupPresentationController.swift
@@ -53,7 +53,7 @@ class PopupTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegat
 }
 
 extension UIViewController {
-    func presentPopup(presentedViewController: UIViewController) {
+    public func presentPopup(presentedViewController: UIViewController) {
         let overlayTransitioningDelegate = PopupTransitioningDelegate()
         presentedViewController.transitioningDelegate = overlayTransitioningDelegate
         presentedViewController.modalPresentationStyle = .custom

--- a/Projects/DesignSystem/Sources/Popup/PopupViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/Popup/PopupViewController+Demo.swift
@@ -141,11 +141,11 @@ public class PopupViewController: DesignSystemBaseViewController {
 
 // MARK: - 여기서 popup action 처리
 extension PopupViewController: YBPopupViewControllerDelegate {
-    func cancelButtonTapped() {
+    public func cancelButtonTapped() {
         print("취소")
     }
     
-    func actionButtonTapped() {
+    public func actionButtonTapped() {
         print("액션")
     }
 }

--- a/Projects/DesignSystem/Sources/Popup/YBPopupTypeViewController.swift
+++ b/Projects/DesignSystem/Sources/Popup/YBPopupTypeViewController.swift
@@ -9,15 +9,14 @@
 import UIKit
 import SnapKit
 
-protocol YBPopupViewControllerDelegate: AnyObject {
+public protocol YBPopupViewControllerDelegate: AnyObject {
     func cancelButtonTapped()
     func actionButtonTapped()
 }
 
 final public class YBPopupTypeViewController: YBPopupViewController {
     
-    weak var delegate: YBPopupViewControllerDelegate?
-    
+    public weak var delegate: YBPopupViewControllerDelegate?
     
     // MARK: - Properties
     private let popupIconImageView = UIImageView()

--- a/Projects/Features/Expenditure/Sources/Coordinator/ExpenditureCoordinator.swift
+++ b/Projects/Features/Expenditure/Sources/Coordinator/ExpenditureCoordinator.swift
@@ -18,6 +18,10 @@ import Dependencies
 import YBDependency
 import UseCase
 
+public protocol ExpenditureCoordinatorDelegate: AnyObject {
+    func deletedTrip()
+}
+
 final public class ExpenditureCoordinator: NSObject, ExpenditureCoordinatorInterface {
     public var viewControllerRef: UIViewController?
     public var childCoordinators = [Coordinator]()
@@ -28,6 +32,7 @@ final public class ExpenditureCoordinator: NSObject, ExpenditureCoordinatorInter
 
     public var parent: TripCoordinatorInterface?
     public let tripItem: TripItem
+    public weak var delegate: ExpenditureCoordinatorDelegate?
 
     public init(navigationController: UINavigationController, tripItem: TripItem) {
         self.navigationController = navigationController
@@ -117,6 +122,7 @@ extension ExpenditureCoordinator {
         if let expenditureNavigationController {
             expenditureNavigationController.tabBarController?.tabBar.isHidden = true
             let settingCoordinator = SettingCoordinator(navigationController: expenditureNavigationController, tripItem: tripItem)
+            settingCoordinator.delegate = self
             settingCoordinator.parent = self
             addChild(settingCoordinator)
             settingCoordinator.start(animated: true)
@@ -143,5 +149,12 @@ extension ExpenditureCoordinator {
 extension ExpenditureCoordinator: ExpenditureAddCoordinatorDelegate {
     public func dismissRegisterExpense(editDate: Date) {
         expenditureViewController?.getExpenseList(editDate: editDate)
+    }
+}
+
+// MARK: - 여행 삭제 후
+extension ExpenditureCoordinator: SettingCoordinatorDelegate {
+    public func deletedTrip() {
+        delegate?.deletedTrip()
     }
 }

--- a/Projects/Features/Home/Sources/Coordinator/HomeCoordinator.swift
+++ b/Projects/Features/Home/Sources/Coordinator/HomeCoordinator.swift
@@ -16,6 +16,7 @@ import MyPage
 
 public protocol HomeCoordinatorDelegate: AnyObject {
     func finishedRegistration()
+    func deletedTrip()
 }
 
 final public class HomeCoordinator: HomeCoordinatorInterface {
@@ -46,6 +47,7 @@ extension HomeCoordinator {
 
     public func trip(tripItem: TripItem) {
         let tripCoordinator = TripCoordinator(navigationController: navigationController, tripItem: tripItem)
+        tripCoordinator.delegate = self
         tripCoordinator.parent = self
         addChild(tripCoordinator)
         tripCoordinator.start(animated: true)
@@ -60,5 +62,11 @@ extension HomeCoordinator {
 extension HomeCoordinator: TravelRegistrationCoordinatorDelegate {
     public func finishedRegistration() {
         delegate?.finishedRegistration()
+    }
+}
+
+extension HomeCoordinator: TripCoordinatorDelegate {
+    public func deletedTrip() {
+        delegate?.deletedTrip()
     }
 }

--- a/Projects/Features/Home/Sources/Presentation/SubViews/HomeCollectionHeaderViewCell.swift
+++ b/Projects/Features/Home/Sources/Presentation/SubViews/HomeCollectionHeaderViewCell.swift
@@ -71,10 +71,12 @@ class HomeCollectionHeaderViewCell: UICollectionViewCell {
     }
     
     func configure(fetchUserResponse: FetchUserResponse) {
-        guard let profileImageUrl = URL(string: fetchUserResponse.profileImage ?? "\(YeoBeeAPI.shared.baseImageURL ?? "")/static/user/profile/profile0.png") else { return }
-        
+        if let profileImageUrl = URL(string: fetchUserResponse.profileImage ?? "") {
+            profileButton.profileImageView.kf.setImage(with: profileImageUrl)
+        } else {
+            profileButton.profileImageView.image = DesignSystemAsset.Icons.face0.image
+        }
         profileButton.profileNameLabel.text = fetchUserResponse.nickname
-        profileButton.profileImageView.kf.setImage(with: profileImageUrl)
     }
     
     private func bind() {

--- a/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
@@ -320,10 +320,16 @@ extension HomeViewController: HomeSectionHeaderViewDelegate {
 // MARK: - 여행 등록 완료 후
 extension HomeViewController: HomeCoordinatorDelegate {
     public func finishedRegistration() {
-        reactor.homeTripUseCase()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.reactor.homeTripUseCase()
             let toast = Toast.text(icon: .complete, "새로운 여행이 등록 되었어요!")
             toast.show()
+        }
+    }
+    
+    public func deletedTrip() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.reactor.homeTripUseCase()
         }
     }
 }

--- a/Projects/Features/MyPage/Sources/MyPageViewController.swift
+++ b/Projects/Features/MyPage/Sources/MyPageViewController.swift
@@ -269,11 +269,11 @@ extension MyPageViewController: UITableViewDataSource {
         if indexPath.section == 0 {
             cell.titleLabel.text = supportMenus[indexPath.row]
             if indexPath.row == 3 {
-                cell.nextImage.isHidden = true
+                cell.nextImageView.isHidden = true
                 cell.versionLabel.isHidden = false
                 cell.isUserInteractionEnabled = false
             } else {
-                cell.nextImage.isHidden = false
+                cell.nextImageView.isHidden = false
                 cell.versionLabel.isHidden = true
                 cell.isUserInteractionEnabled = true
             }

--- a/Projects/Features/MyPage/Tests/MyPageTests.swift
+++ b/Projects/Features/MyPage/Tests/MyPageTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class MyPageTests: XCTestCase {
+    func test_example() {
+        XCTAssertEqual("MyPage", "MyPage")
+    }
+}

--- a/Projects/Features/Setting/Sources/Coordinator/SettingCoordinator.swift
+++ b/Projects/Features/Setting/Sources/Coordinator/SettingCoordinator.swift
@@ -11,12 +11,17 @@ import UIKit
 import Coordinator
 import Entity
 
+public protocol SettingCoordinatorDelegate: AnyObject {
+    func deletedTrip()
+}
+
 final public class SettingCoordinator: SettingCoordinatorInterface {
     public var navigationController: UINavigationController
     public var viewControllerRef: UIViewController?
     public var childCoordinators = [Coordinator]()
     public var parent: ExpenditureCoordinatorInterface?
     public let tripItem: TripItem
+    public weak var delegate: SettingCoordinatorDelegate?
 
     public init(navigationController: UINavigationController, tripItem: TripItem) {
         self.navigationController = navigationController
@@ -34,6 +39,12 @@ final public class SettingCoordinator: SettingCoordinatorInterface {
         navigationController.popViewController(animated: true)
         navigationController.tabBarController?.tabBar.isHidden = false
         parent?.childDidFinish(self)
+    }
+    
+    public func deletedTrip() {
+        delegate?.deletedTrip()
+        coordinatorDidFinish()
+        parent?.coordinatorDidFinish()
     }
 
     deinit {

--- a/Projects/Features/Setting/Sources/Presentation/Reactor/SettingReactor.swift
+++ b/Projects/Features/Setting/Sources/Presentation/Reactor/SettingReactor.swift
@@ -22,18 +22,21 @@ public final class SettingReactor: Reactor {
         case companions([TripUserItem])
         case currencies([Currency])
         case tripItem(TripItem)
+        case deleteTrip(Bool)
     }
     
     public enum Mutation {
         case companions([TripUserItem])
         case currencies([Currency])
         case tripItem(TripItem)
+        case deleteTrip(Bool)
     }
     
     public struct State {
         var companions: [TripUserItem] = []
         var currencies: [Currency] = []
         var tripItem: TripItem
+        var deletedTrip: Bool = false
     }
     
     @Dependency(\.tripUseCase) var tripUseCase
@@ -53,6 +56,8 @@ public final class SettingReactor: Reactor {
             return .just(.currencies(currencies))
         case .tripItem(let tripItem):
             return .just(.tripItem(tripItem))
+        case .deleteTrip(let isDeleted):
+            return .just(.deleteTrip(isDeleted))
         }
     }
     
@@ -67,6 +72,8 @@ public final class SettingReactor: Reactor {
             newState.currencies = currencies
         case .tripItem(let tripItem):
             newState.tripItem = tripItem
+        case .deleteTrip(let isDeleted):
+            newState.deletedTrip = isDeleted
         }
         
         return newState
@@ -95,6 +102,15 @@ public final class SettingReactor: Reactor {
             if companionsResult.count > 1 {
                 action.onNext(.companions(companionsResult))
             }
+        }
+    }
+    
+    func deleteTripUseCase() {
+        let currentTripItem = currentState.tripItem
+        
+        Task {
+            let deleteTripResult = try await tripUseCase.deleteTrip(currentTripItem.id)
+            action.onNext(.deleteTrip(deleteTripResult))
         }
     }
 }

--- a/Projects/Features/Setting/Sources/Presentation/Reactor/SettingReactor.swift
+++ b/Projects/Features/Setting/Sources/Presentation/Reactor/SettingReactor.swift
@@ -75,7 +75,9 @@ public final class SettingReactor: Reactor {
     func settingUseCase() {
         let currentTripItem = currentState.tripItem
         let companions = currentTripItem.tripUserList
-        action.onNext(.companions(companions))
+        if companions.count > 1 {
+            action.onNext(.companions(companions))
+        }
         
         Task {
             let currencyResult = try await currencyUseCase.getTripCurrencies(currentTripItem.id)
@@ -90,7 +92,9 @@ public final class SettingReactor: Reactor {
             let tripResult = try await tripUseCase.getTrip(currentTripItem.id)
             let companionsResult = tripResult.tripUserList
             action.onNext(.tripItem(tripResult))
-            action.onNext(.companions(companionsResult))
+            if companionsResult.count > 1 {
+                action.onNext(.companions(companionsResult))
+            }
         }
     }
 }

--- a/Projects/Features/Setting/Sources/Presentation/SubViews/SettingBottomSheetViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/SubViews/SettingBottomSheetViewController.swift
@@ -30,14 +30,14 @@ public class SettingBottomSheetViewController: YBBottomSheetViewController {
         return $0
     }(UIButton())
     
-    private let modifyDateButton: UIButton = {
-        $0.setTitle("날짜 수정", for: .normal)
-        $0.setTitleColor(YBColor.gray6.color, for: .normal)
-        $0.titleLabel?.font = YBFont.body1.font
-        $0.contentHorizontalAlignment = .left
-        $0.addTarget(self, action: #selector(modifyDateButtonTapped), for: .touchUpInside)
-        return $0
-    }(UIButton())
+//    private let modifyDateButton: UIButton = {
+//        $0.setTitle("날짜 수정", for: .normal)
+//        $0.setTitleColor(YBColor.gray6.color, for: .normal)
+//        $0.titleLabel?.font = YBFont.body1.font
+//        $0.contentHorizontalAlignment = .left
+//        $0.addTarget(self, action: #selector(modifyDateButtonTapped), for: .touchUpInside)
+//        return $0
+//    }(UIButton())
     
     // MARK: - Life Cycles
     public override func viewDidLoad() {
@@ -61,7 +61,7 @@ public class SettingBottomSheetViewController: YBBottomSheetViewController {
     private func setLayouts() {
         containerView.addSubview(settingTitleLabel)
         containerView.addSubview(modifyTitleButton)
-        containerView.addSubview(modifyDateButton)
+//        containerView.addSubview(modifyDateButton)
         
         settingTitleLabel.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
@@ -71,11 +71,11 @@ public class SettingBottomSheetViewController: YBBottomSheetViewController {
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(25)
         }
-        modifyDateButton.snp.makeConstraints { make in
-            make.top.equalTo(modifyTitleButton.snp.bottom).inset(-16)
-            make.leading.trailing.equalToSuperview()
-            make.height.equalTo(25)
-        }
+//        modifyDateButton.snp.makeConstraints { make in
+//            make.top.equalTo(modifyTitleButton.snp.bottom).inset(-16)
+//            make.leading.trailing.equalToSuperview()
+//            make.height.equalTo(25)
+//        }
     }
     
     // MARK: - Handler

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
@@ -245,7 +245,7 @@ extension SettingViewController: SettingTableHeaderViewDelegate {
     func modifyButtonTapped() {
         let settingBottomSheetViewController = SettingBottomSheetViewController()
         settingBottomSheetViewController.delegate = self
-        presentBottomSheet(presentedViewController: settingBottomSheetViewController, height: 250)
+        presentBottomSheet(presentedViewController: settingBottomSheetViewController, height: 180)
     }
 }
 

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
@@ -131,9 +131,9 @@ public final class SettingViewController: UIViewController {
     }
     
     @objc private func trashButtonTapped() {
-        // MARK: - [TODO] 삭제 Alert
-        coordinator.coordinatorDidFinish()
-        coordinator.parent?.coordinatorDidFinish()
+        let popupViewController = YBPopupTypeViewController(popupType: .tripDelete)
+        popupViewController.delegate = self
+        presentPopup(presentedViewController: popupViewController)
     }
 
     deinit {
@@ -228,6 +228,15 @@ extension SettingViewController: View {
                 self.configureSnapshot(companions: currentCompanion, currencies: currencies)
             }
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.deletedTrip }
+            .bind { [weak self] isDeleted in
+                if isDeleted {
+                    self?.coordinator.deletedTrip()
+                }
+            }
+            .disposed(by: disposeBag)
     }
 }
 
@@ -275,5 +284,16 @@ extension SettingViewController: SettingCompanionCellDelegate {
 extension SettingViewController: ModifiedSettingViewControllerDelegate {
     func modified() {
         reactor.updateSettingUseCase()
+    }
+}
+
+// MARK: - 여행 삭제 popup
+extension SettingViewController: YBPopupViewControllerDelegate {
+    public func cancelButtonTapped() {
+        return
+    }
+    
+    public func actionButtonTapped() {
+        reactor.deleteTripUseCase()
     }
 }

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarViewController.swift
@@ -378,11 +378,24 @@ extension CalendarViewController: View {
         reactor.state
             .map { $0.checkedDateValidation }
             .observe(on: MainScheduler.instance)
-            .bind { isOverlap in
+            .bind { [weak self] isOverlap in
                 if isOverlap {
-                    print("여행이 겹쳤어요 - alert")
+                    let popupController = YBPopupTypeViewController(popupType: .calendarWarning)
+                    popupController.delegate = self
+                    self?.presentPopup(presentedViewController: popupController)
                 }
             }
             .disposed(by: disposeBag)
+    }
+}
+
+extension CalendarViewController: YBPopupViewControllerDelegate {
+    public func cancelButtonTapped() {
+        clearSelectedDates(in: calendarView.calendar)
+        configureVisibleCells()
+    }
+    
+    public func actionButtonTapped() {
+        return
     }
 }

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/AddCompanionView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/AddCompanionView.swift
@@ -73,9 +73,11 @@ final class AddCompanionView: UIView {
     }
     
     func configure(fetchUserResponse: FetchUserResponse) {
-        guard let profileImageUrl = URL(string: fetchUserResponse.profileImage ?? "\(YeoBeeAPI.shared.baseImageURL ?? "")/static/user/profile/profile0.png") else { return }
-        
+        if let profileImageUrl = URL(string: fetchUserResponse.profileImage ?? "") {
+            myProfileImageView.kf.setImage(with: profileImageUrl)
+        } else {
+            myProfileImageView.image = DesignSystemAsset.Icons.face0.image
+        }
         myProfileNameLabel.text = fetchUserResponse.nickname
-        myProfileImageView.kf.setImage(with: profileImageUrl)
     }
 }

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/CompanionTableViewCell.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/SubViews/CompanionTableViewCell.swift
@@ -93,12 +93,15 @@ class CompanionTableViewCell: UITableViewCell {
     }
     
     func configure() {
-        guard let companion = companion,
-              let imageUrl = URL(string: companion.imageUrl) else { return }
+        guard let companion = companion else { return }
         
+        if let profileImageUrl = URL(string: companion.imageUrl) {
+            profileImageView.kf.indicatorType = .activity
+            profileImageView.kf.setImage(with: profileImageUrl)
+        } else {
+            profileImageView.image = DesignSystemAsset.Icons.face0.image
+        }
         profileNameLabel.text = companion.name
-        profileImageView.kf.indicatorType = .activity
-        profileImageView.kf.setImage(with: imageUrl)
     }
     
     private func bind() {

--- a/Projects/Features/Trip/Sources/Coordinator/TripCoordinator.swift
+++ b/Projects/Features/Trip/Sources/Coordinator/TripCoordinator.swift
@@ -12,6 +12,10 @@ import Entity
 import Expenditure
 import DesignSystem
 
+public protocol TripCoordinatorDelegate: AnyObject {
+    func deletedTrip()
+}
+
 final public class TripCoordinator: TripCoordinatorInterface {
     public var navigationController: UINavigationController
     public var viewControllerRef: UIViewController?
@@ -19,6 +23,7 @@ final public class TripCoordinator: TripCoordinatorInterface {
     public var childCoordinators = [Coordinator]()
     public var parent: HomeCoordinatorInterface?
     public let tripItem: TripItem
+    public weak var delegate: TripCoordinatorDelegate?
 
     public init(navigationController: UINavigationController, tripItem: TripItem) {
         self.navigationController = navigationController
@@ -27,6 +32,7 @@ final public class TripCoordinator: TripCoordinatorInterface {
 
     public func start(animated: Bool = false) {
         let expenditureCoordinator = ExpenditureCoordinator(navigationController: UINavigationController(), tripItem: tripItem)
+        expenditureCoordinator.delegate = self
         expenditureCoordinator.parent = self
         addChild(expenditureCoordinator)
 
@@ -51,5 +57,11 @@ final public class TripCoordinator: TripCoordinatorInterface {
 
     deinit {
         print("TripCoordinator is de-initialized.")
+    }
+}
+
+extension TripCoordinator: ExpenditureCoordinatorDelegate {
+    public func deletedTrip() {
+        delegate?.deletedTrip()
     }
 }

--- a/Projects/Repository/Sources/TripRepository.swift
+++ b/Projects/Repository/Sources/TripRepository.swift
@@ -25,6 +25,7 @@ public protocol TripRepositoryInterface {
     func getPresentTrip(_ pageIndex: Int, _ pageSize: Int) async throws -> TripResponse
     func getFutureTrip(_ pageIndex: Int, _ pageSize: Int) async throws -> TripResponse
     func checkDateOverlap(_ startDate: String, _ endDate: String) async throws -> TripDateValidationResponse
+    func deleteTrip(_ tripId: Int) async throws -> Bool
     func postTrip(
         _ title: String,
         _ startDate: String,
@@ -103,6 +104,17 @@ final public class TripRepository: TripRepositoryInterface {
             return try decode(data: response.data)
         case .failure(let failure):
             throw failure
+        }
+    }
+    
+    public func deleteTrip(_ tripId: Int) async throws -> Bool {
+        let result = await provider.request(.deleteTrip(tripId))
+        
+        switch result {
+        case .success(_):
+            return true
+        case .failure(_):
+            return false
         }
     }
     

--- a/Projects/Repository/Sources/TripRepository.swift
+++ b/Projects/Repository/Sources/TripRepository.swift
@@ -111,9 +111,9 @@ final public class TripRepository: TripRepositoryInterface {
         let result = await provider.request(.deleteTrip(tripId))
         
         switch result {
-        case .success(_):
+        case .success:
             return true
-        case .failure(_):
+        case .failure:
             return false
         }
     }
@@ -129,7 +129,6 @@ final public class TripRepository: TripRepositoryInterface {
         
         switch result {
         case let .success(response):
-            print("success: \(response.data)")
             return try decode(data: response.data)
         case .failure(let failure):
             throw failure

--- a/Projects/UseCase/Sources/TripUseCase.swift
+++ b/Projects/UseCase/Sources/TripUseCase.swift
@@ -25,6 +25,7 @@ public struct TripUseCase {
     public var getPresentTrip: @Sendable (_ pageIndex: Int, _ pageSize: Int) async throws -> TripResponse
     public var getFutureTrip: @Sendable (_ pageIndex: Int, _ pageSize: Int) async throws -> TripResponse
     public var checkDateOverlap: @Sendable (_ startDate: String, _ endDate: String) async throws -> TripDateValidationResponse
+    public var deleteTrip: @Sendable (_ tripId: Int) async throws -> Bool
     public var postTrip: @Sendable (
         _ title: String,
         _ startDate: String,
@@ -60,6 +61,8 @@ extension TripUseCase: DependencyKey {
             return try await tripRepository.getFutureTrip(pageIndex, pageSize)
         }, checkDateOverlap: { startDate, endDate in
             return try await tripRepository.checkDateOverlap(startDate, endDate)
+        }, deleteTrip: { tripId in
+            return try await tripRepository.deleteTrip(tripId)
         }, postTrip: { title, startDate, endDate, countryList, tripUserList in
             return try await tripRepository.postTrip(title, startDate, endDate, countryList, tripUserList)
         })

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -14,6 +14,7 @@ extension Project {
             "CFBundleVersion": "1",
             "UIMainStoryboardFile": "",
             "UILaunchStoryboardName": "LaunchScreen",
+            "BASE_IMAGE_URL": "$(BASE_IMAGE_URL)",
             "BASE_URL": "$(BASE_URL)",
             "LSApplicationQueriesSchemes": [
                   "kakaokompassauth",


### PR DESCRIPTION
## 이슈번호
[YB-130]

## 수정 사항
- popup public으로 사용가능하게 변경했습니다.
- 여행 등록 검증 Alert 처리했습니다.
- 여행 설정 혼자 여행 시 보였던 동행자를 1명 이상으로 로직 변경했습니다.
- 여행 삭제 Alert와 삭제 API 연결했습니다.
- 여행 등록 후 또는 여행 삭제 후 홈 API 갱신하도록 변경했습니다.

## 화면 (Optional)
|여행 등록 후 삭제|
| --- |
| <img width="386" alt="스크린샷 2024-02-20 오전 01 10 23" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/5170a13e-c900-4c0c-abe4-5f268ef80806"> |


## target module
- Setting, Home, TravelRegistration

## 참고사항
- 다음 PR에서 여행 환율 수정 올릴게요!


[YB-130]: https://yeobee.atlassian.net/browse/YB-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ