### PR TITLE
[YB-131] 마이페이지 | 프로필 수정 화면 | 닉네임 변경 로직

### DIFF
--- a/Projects/Entity/Sources/API/User/FetchUserResponse.swift
+++ b/Projects/Entity/Sources/API/User/FetchUserResponse.swift
@@ -14,4 +14,5 @@ public struct FetchUserResponse: Codable, Hashable {
     public var profileImage: String?
     public var authProviderType: AuthProviderType
     public var userState: UserState
+    public var tripCount: Int
 }

--- a/Projects/Features/MyPage/Project.swift
+++ b/Projects/Features/MyPage/Project.swift
@@ -22,7 +22,8 @@ let project = Project(
                 .RxSwift,
                 .RxCocoa,
                 .reactorKit,
-                .kingfisher
+                .kingfisher,
+                .usecase
             ]
         ),
         Project.target(

--- a/Projects/Features/MyPage/Sources/Coordinator/MyPageCoordinator.swift
+++ b/Projects/Features/MyPage/Sources/Coordinator/MyPageCoordinator.swift
@@ -8,6 +8,7 @@
 
 import Coordinator
 import UIKit
+import Entity
 
 final public class MyPageCoordinator: MyPageCoordinatorInterface {
     public var navigationController: UINavigationController
@@ -32,6 +33,12 @@ final public class MyPageCoordinator: MyPageCoordinatorInterface {
         navigationController.popViewController(animated: true)
     }
     
+    public func editProfile(userInfo: FetchUserResponse?) {
+        let editProfileVC = EditMyProfileViewController()
+        let reactor = EditMyProfileReactor(userInfo: userInfo)
+        editProfileVC.reactor = reactor
+        self.navigationController.pushViewController(editProfileVC, animated: true)
+    }
     //    public func login() {
     //        let signCoordinator = SignCoordinator(navigationController: self.navigationController)
     //        signCoordinator.start(animated: true)

--- a/Projects/Features/MyPage/Sources/EditMyProfileReactor.swift
+++ b/Projects/Features/MyPage/Sources/EditMyProfileReactor.swift
@@ -24,6 +24,7 @@ public final class EditMyProfileReactor: Reactor {
         case setNicknameEmpty(Bool)
         case setNickname(String, Bool)
         case setErrorMessage(String?)
+        case editNicknameSuccess(Bool)
     }
     
     public struct State {
@@ -31,6 +32,7 @@ public final class EditMyProfileReactor: Reactor {
         var nickname: String
         var errorMessage: String?
         var userInfo: FetchUserResponse?
+        var isEditSuccess: Bool
     }
     
     public let initialState: State
@@ -39,7 +41,8 @@ public final class EditMyProfileReactor: Reactor {
         self.initialState = .init(
             isNicknameEmpty: true,
             nickname: "",
-            userInfo: userInfo
+            userInfo: userInfo,
+            isEditSuccess: false
         )
     }
     
@@ -57,6 +60,7 @@ public final class EditMyProfileReactor: Reactor {
                         observer.onNext(.setErrorMessage(nil))
                         Task { @MainActor in
                             try await self.updateUserInfo()
+                            observer.onNext(.editNicknameSuccess(true))
                         }
                     }
                     return Disposables.create()
@@ -74,6 +78,8 @@ public final class EditMyProfileReactor: Reactor {
                 newState.isNicknameEmpty = isEmpty
             case .setErrorMessage(let message):
                 newState.errorMessage = message
+            case .editNicknameSuccess(let isSuccess):
+                newState.isEditSuccess = isSuccess
         }
         return newState
     }

--- a/Projects/Features/MyPage/Sources/EditMyProfileReactor.swift
+++ b/Projects/Features/MyPage/Sources/EditMyProfileReactor.swift
@@ -7,3 +7,90 @@
 //
 
 import Foundation
+import ReactorKit
+import RxSwift
+
+import Repository
+import YBNetwork
+import Entity
+
+public final class EditMyProfileReactor: Reactor {
+    public enum Action  {
+        case editButtonTapped
+        case updateNickname(String)
+    }
+    
+    public enum Mutation {
+        case setNicknameEmpty(Bool)
+        case setNickname(String, Bool)
+        case setErrorMessage(String?)
+    }
+    
+    public struct State {
+        @Pulse var isNicknameEmpty: Bool
+        var nickname: String
+        var errorMessage: String?
+        var userInfo: FetchUserResponse?
+    }
+    
+    public let initialState: State
+    
+    public init(userInfo: FetchUserResponse?) {
+        self.initialState = .init(
+            isNicknameEmpty: true,
+            nickname: "",
+            userInfo: userInfo
+        )
+    }
+    
+    let userInfoRepository = UserInfoRepository()
+    
+    public func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+            case .updateNickname(let nickname):
+                return Observable.just(Mutation.setNickname(nickname, nickname.isEmpty))
+            case .editButtonTapped:
+                return Observable.create { observer in
+                    if let errorMessage = self.isValidNickname(self.currentState.nickname) {
+                        observer.onNext(.setErrorMessage(errorMessage))
+                    } else {
+                        observer.onNext(.setErrorMessage(nil))
+                        Task { @MainActor in
+                            try await self.updateUserInfo()
+                        }
+                    }
+                    return Disposables.create()
+                }
+        }
+    }
+    
+    public func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+            case .setNicknameEmpty(let isEmpty):
+                newState.isNicknameEmpty = isEmpty
+            case .setNickname(let nickname, let isEmpty):
+                newState.nickname = nickname
+                newState.isNicknameEmpty = isEmpty
+            case .setErrorMessage(let message):
+                newState.errorMessage = message
+        }
+        return newState
+    }
+    
+    private func isValidNickname(_ nickname: String) -> String? {
+        if !NSPredicate(format: "SELF MATCHES %@", "^[가-힣ㄱ-ㅎㅏ-ㅣA-Za-z0-9]+$").evaluate(with: nickname) {
+            return "특수문자 사용이 불가해요."
+        }
+        if nickname.count > 5 {
+            return "한글, 영문 포함 5자 이내로 입력해주세요."
+        }
+        return nil
+    }
+    
+    private func updateUserInfo() async throws -> Void {
+        let nickname = currentState.nickname
+        let request = UpdateUserInfoRequest(nickname: nickname)
+        try await userInfoRepository.updateUserInfo(request: request)
+    }
+}

--- a/Projects/Features/MyPage/Sources/EditMyProfileReactor.swift
+++ b/Projects/Features/MyPage/Sources/EditMyProfileReactor.swift
@@ -1,0 +1,9 @@
+//
+//  EditMyProfileReactor.swift
+//  MyPage
+//
+//  Created by 김태형 on 2/19/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Features/MyPage/Sources/EditMyProfileViewController.swift
+++ b/Projects/Features/MyPage/Sources/EditMyProfileViewController.swift
@@ -1,0 +1,9 @@
+//
+//  EditMyProfileViewController.swift
+//  MyPage
+//
+//  Created by 김태형 on 2/19/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Features/MyPage/Sources/EditMyProfileViewController.swift
+++ b/Projects/Features/MyPage/Sources/EditMyProfileViewController.swift
@@ -17,8 +17,8 @@ import SnapKit
 
 public final class EditMyProfileViewController: UIViewController, View {
     public var disposeBag: DisposeBag = DisposeBag()
-    
-    let profileImageView = UIImageView(image: DesignSystemAsset.Icons.airplane.image)
+    //TODO: 프로필 이미지 기능 추가시 아래 이미지 수정
+    let profileImageView = UIImageView(image: DesignSystemAsset.Icons.face0.image)
     let nameLabel = YBLabel(text: "이름", font: .title1)
     let linkedAccountLabel = YBLabel(text: "연결된 계정", font: .title1)
     let nicknameTextField = YBTextField()

--- a/Projects/Features/MyPage/Sources/EditMyProfileViewController.swift
+++ b/Projects/Features/MyPage/Sources/EditMyProfileViewController.swift
@@ -76,6 +76,15 @@ public final class EditMyProfileViewController: UIViewController, View {
                 self?.errorDescriptionLabel.text = errorMessage
             }
             .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.isEditSuccess } //TODO: updateUserInfo 2번 호출되는문제 해결 필요
+            .distinctUntilChanged()
+            .bind { [weak self] isSuccess in
+                if isSuccess {
+                    self?.navigationController?.popViewController(animated: true)
+                }
+            }
+            .disposed(by: disposeBag)
     }
     
     private func configureBar() {

--- a/Projects/Features/MyPage/Sources/EditMyProfileViewController.swift
+++ b/Projects/Features/MyPage/Sources/EditMyProfileViewController.swift
@@ -6,4 +6,173 @@
 //  Copyright © 2024 YeoBee.com. All rights reserved.
 //
 
-import Foundation
+import UIKit
+import Coordinator
+import ReactorKit
+import RxSwift
+import RxCocoa
+
+import DesignSystem
+import SnapKit
+
+public final class EditMyProfileViewController: UIViewController, View {
+    public var disposeBag: DisposeBag = DisposeBag()
+    
+    let profileImageView = UIImageView(image: DesignSystemAsset.Icons.airplane.image)
+    let nameLabel = YBLabel(text: "이름", font: .title1)
+    let linkedAccountLabel = YBLabel(text: "연결된 계정", font: .title1)
+    let nicknameTextField = YBTextField()
+    let socialTypeIamgeView = UIImageView()
+    let circleView: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = 15
+        return view
+    }()
+    let socialTypeLabel = YBLabel(font: .title1)
+    let errorDescriptionLabel = YBLabel(text: "", font: .body4, textColor: .mainRed)
+    let editButton = YBTextButton(text: "수정하기", appearance: .selectDisable, size: .medium)
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        setupViews()
+        setSocialImage()
+        setLayouts()
+        configureBar()
+    }
+    
+    required convenience init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public func bind(reactor: EditMyProfileReactor) {
+        //Action
+        nicknameTextField.rx.text.orEmpty
+            .map { Reactor.Action.updateNickname($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        editButton.rx.tap
+            .map { Reactor.Action.editButtonTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        //State
+        reactor.pulse(\.$isNicknameEmpty)
+            .bind { [weak self] isNicknameEmpty in
+                if isNicknameEmpty {
+                    self?.editButton.setAppearance(appearance: .defaultDisable)
+                    self?.editButton.setTitle("수정하기", for: .normal)
+                    self?.editButton.isEnabled = false
+                } else {
+                    self?.editButton.setAppearance(appearance: .default)
+                    self?.editButton.setTitle("수정하기", for: .normal)
+                    self?.editButton.isEnabled = true
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.errorMessage }
+            .bind { [weak self] errorMessage in
+                self?.errorDescriptionLabel.text = errorMessage
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func configureBar() {
+        let backImage = UIImage(systemName: "chevron.backward")?.withTintColor(YBColor.gray5.color, renderingMode: .alwaysOriginal)
+        let backButton = UIBarButtonItem(image: backImage, style: .plain, target: self, action: #selector(backButtonTapped))
+        self.navigationItem.leftBarButtonItem = backButton
+        self.navigationItem.title = "내 정보"
+    }
+    
+    @objc private func backButtonTapped() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    private func setSocialImage() {
+        guard let socialType = reactor?.currentState.userInfo?.authProviderType else {
+            return
+        }
+        if socialType == .kakao {
+            socialTypeIamgeView.image = DesignSystemAsset.Icons.kakao.image
+            socialTypeLabel.text = "카카오"
+            circleView.backgroundColor = DesignSystemAsset.Colors.kakaoYellow.color
+        } else {
+            socialTypeIamgeView.image = DesignSystemAsset.Icons.apple.image
+            socialTypeLabel.text = "Apple"
+            circleView.backgroundColor = .black
+        }
+    }
+    
+    private func setupViews() {
+        view.backgroundColor = YBColor.white.color
+        nicknameTextField.placeholder = reactor?.currentState.userInfo?.nickname
+        nicknameTextField.textColor = .black
+        nicknameTextField.becomeFirstResponder()
+    }
+    
+    private func setLayouts() {
+        view.addSubview(profileImageView)
+        view.addSubview(nameLabel)
+        view.addSubview(nicknameTextField)
+        view.addSubview(editButton)
+        view.addSubview(errorDescriptionLabel)
+        view.addSubview(linkedAccountLabel)
+        view.addSubview(socialTypeLabel)
+        view.addSubview(circleView)
+        view.addSubview(socialTypeIamgeView)
+        
+        profileImageView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(28)
+            make.centerX.equalTo(view.snp.centerX)
+            make.size.equalTo(102)
+        }
+        
+        nameLabel.snp.makeConstraints { make in
+            make.top.equalTo(profileImageView.snp.bottom).offset(30)
+            make.leading.equalTo(view.snp.leading).offset(24)
+            make.height.equalTo(50)
+            make.width.equalTo(30)
+        }
+        
+        nicknameTextField.snp.makeConstraints { make in
+            make.top.equalTo(profileImageView.snp.bottom).offset(30)
+            make.leading.equalTo(nameLabel.snp.trailing).offset(57)
+            make.trailing.equalTo(view.snp.trailing).offset(-24)
+        }
+        
+        errorDescriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(nicknameTextField.snp.bottom).offset(10)
+            make.trailing.equalTo(view.snp.trailing).offset(-24)
+        }
+        
+        linkedAccountLabel.snp.makeConstraints { make in
+            make.top.equalTo(errorDescriptionLabel.snp.bottom).offset(30)
+            make.leading.equalTo(nameLabel.snp.leading)
+            make.height.equalTo(30)
+        }
+        
+        socialTypeLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(socialTypeIamgeView)
+            make.trailing.equalTo(view.snp.trailing).offset(-24)
+        }
+        
+        circleView.snp.makeConstraints { make in
+            make.top.equalTo(linkedAccountLabel.snp.top)
+            make.trailing.equalTo(socialTypeLabel.snp.leading).offset(-10)
+            make.size.equalTo(30)
+        }
+        
+        socialTypeIamgeView.snp.makeConstraints { make in
+            make.top.equalTo(linkedAccountLabel.snp.top)
+            make.trailing.equalTo(socialTypeLabel.snp.leading).offset(-10)
+            make.size.equalTo(30)
+        }
+        
+        editButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-68)
+            make.leading.equalTo(view.snp.leading).offset(24)
+            make.trailing.equalTo(view.snp.trailing).offset(-24)
+        }
+    }
+}

--- a/Projects/Features/MyPage/Sources/MyPageProfileButton.swift
+++ b/Projects/Features/MyPage/Sources/MyPageProfileButton.swift
@@ -11,9 +11,14 @@ import DesignSystem
 import SnapKit
 
 final class MyPageProfileButton: UIButton {
-    private var nickname: String
-    private let profileNameLabel = YBLabel(text: "양송이", font: .header2, textColor: .black)
+    var nickname: String {
+            didSet {
+                profileNameLabel.text = nickname
+            }
+        }
+    private let profileNameLabel = YBLabel(text: "", font: .header2, textColor: .black)
     private let chevronImageView = UIImageView(image: DesignSystemAsset.Icons.next.image)
+    var onTap: (() -> Void)?
     
     // MARK: - Init
     init(frame: CGRect, nickname: String) {
@@ -21,6 +26,7 @@ final class MyPageProfileButton: UIButton {
         super.init(frame: frame)
         addViews()
         setLayouts()
+        addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }
     
     @available(*, unavailable)
@@ -32,11 +38,9 @@ final class MyPageProfileButton: UIButton {
     private func addViews() {
         addSubview(profileNameLabel)
         addSubview(chevronImageView)
-        
     }
     
     private func setLayouts() {
-        
         profileNameLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview()
         }
@@ -45,4 +49,8 @@ final class MyPageProfileButton: UIButton {
             make.centerY.equalTo(profileNameLabel.snp.centerY)
         }
     }
+    
+    @objc private func buttonTapped() {
+           onTap?()
+       }
 }

--- a/Projects/Features/MyPage/Sources/MyPageViewController.swift
+++ b/Projects/Features/MyPage/Sources/MyPageViewController.swift
@@ -7,12 +7,16 @@
 
 import UIKit
 import ReactorKit
+import RxSwift
+import RxCocoa
+
 import DesignSystem
 
 public class MyPageViewController: UIViewController, View {
     
     public var disposeBag = DisposeBag()
     public var coordinator: MyPageCoordinator?
+    private let reactor = MyPageReactor()
     
     private let supportMenus = ["리뷰 작성하기", "공지사항", "문의하기", "버전 정보"]
     private let supportMenuURLs = ["https://naver.com","https://m.cafe.naver.com/ca-fe/web/cafes/31153021/menus/7","https://m.cafe.naver.com/ca-fe/web/cafes/31153021/menus/1"]
@@ -41,11 +45,12 @@ public class MyPageViewController: UIViewController, View {
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.layer.cornerRadius = 28
-        imageView.image = DesignSystemAsset.Icons.airplane.image
+        //TODO: 프로필 이미지 기능 추가시 아래 이미지 수정
+        imageView.image = DesignSystemAsset.Icons.face0.image
         return imageView
     }()
-    // TODO 양송이 > 유저이름 변경
-    private let nameButton = MyPageProfileButton(frame: CGRect(x: 0, y: 0, width: 81, height: 30), nickname: "양송이")
+    
+    private let nameButton = MyPageProfileButton(frame: CGRect(x: 0, y: 0, width: 81, height: 30), nickname: "")
     private let tripDescriptionLabel = YBLabel(font: .body2, textColor: .gray6)
     private let tripLabel = YBLabel(text: "여행", font: .body3, textColor: .gray4)
     private let tripCountLabel = YBLabel(font: .body3, textColor: .mainGreen)
@@ -67,6 +72,10 @@ public class MyPageViewController: UIViewController, View {
         return imageView
     }()
     
+    override public func viewWillAppear(_ animated: Bool) {
+        reactor.fetchUserInfo()
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         myPageMenuTableView.dataSource = self
@@ -74,9 +83,16 @@ public class MyPageViewController: UIViewController, View {
         navigationController?.isNavigationBarHidden = false
         
         view.backgroundColor = YBColor.gray1.color
+        bind(reactor: reactor)
         setupViews()
         setLayouts()
         configureBar()
+        nameButton.onTap = { [weak self] in
+            let editProfileVC = EditMyProfileViewController()
+            let reactor = EditMyProfileReactor(userInfo: self?.reactor.currentState.userInfo)
+            editProfileVC.reactor = reactor
+            self?.navigationController?.pushViewController(editProfileVC, animated: true)
+        }
     }
     
     required convenience init?(coder aDecoder: NSCoder) {
@@ -93,7 +109,23 @@ public class MyPageViewController: UIViewController, View {
     }
     
     func bindState(reactor: MyPageReactor) {
+        reactor.state.map { $0.userInfo?.nickname }
+            .filter { $0 != nil }
+            .bind { [weak self] nickname in
+                DispatchQueue.main.async {
+                    self?.nameButton.nickname = nickname ?? ""
+                }
+            }
+            .disposed(by: disposeBag)
         
+        reactor.state.map { $0.userInfo?.tripCount }
+            .bind { [weak self] tripCount in
+                DispatchQueue.main.async {
+                    self?.tripCountLabel.text = "\(tripCount ?? 0)개국"
+                    self?.tripDescriptionLabel.text = reactor.tripDescription()
+                }
+            }
+            .disposed(by: disposeBag)
     }
     
     private func configureBar() {
@@ -114,12 +146,15 @@ public class MyPageViewController: UIViewController, View {
         }
     }
     
+//    @objc func rebokeButtonTapped() {
+//        self.navigationController?.pushViewController(<#T##viewController: UIViewController##UIViewController#>, animated: <#T##Bool#>)
+//    }
+    
     private func setupViews() {
         myPageMenuTableView.register(MyPageMenuCell.self, forCellReuseIdentifier: MyPageMenuCell().reuseableIdentifier)
         myPageMenuTableView.separatorStyle = .none
         
-        tripDescriptionLabel.text = "당신은 여비 입문중!"
-        tripCountLabel.text = "1개국"
+        nameButton.setTitle(reactor.currentState.userInfo?.nickname, for: .normal)
         
         proposeTitleLabel.numberOfLines = 0
         proposeTitleLabel.setLineHeight(lineHeight: 22.5)
@@ -222,7 +257,6 @@ public class MyPageViewController: UIViewController, View {
             make.top.equalTo(proposeContentView.snp.top).offset(20)
             make.trailing.equalTo(proposeContentView.snp.trailing).offset(-24)
             make.size.equalTo(86)
-            
         }
         
         myPageMenuTableView.snp.makeConstraints { make in
@@ -269,11 +303,11 @@ extension MyPageViewController: UITableViewDataSource {
         if indexPath.section == 0 {
             cell.titleLabel.text = supportMenus[indexPath.row]
             if indexPath.row == 3 {
-                cell.nextImage.isHidden = true
+                cell.nextImageView.isHidden = true
                 cell.versionLabel.isHidden = false
                 cell.isUserInteractionEnabled = false
             } else {
-                cell.nextImage.isHidden = false
+                cell.nextImageView.isHidden = false
                 cell.versionLabel.isHidden = true
                 cell.isUserInteractionEnabled = true
             }
@@ -295,24 +329,22 @@ extension MyPageViewController: UITableViewDelegate {
         let footerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 100))
         footerView.backgroundColor = .white
         
-        // 첫 번째 버튼 (상단)
-        let topButton = UIButton(type: .system)
-        topButton.frame = CGRect(x: 20, y: 10, width: 56, height: 40)
-        topButton.setTitle("로그아웃", for: .normal)
-        topButton.setTitleColor(YBColor.gray5.color, for: .normal)
-        topButton.titleLabel?.font = YBFont.body3.font
-        // topButton.addTarget(self, action: #selector(topButtonTapped), for: .touchUpInside)
+        let logoutButton = UIButton(type: .system)
+        logoutButton.frame = CGRect(x: 20, y: 10, width: 56, height: 40)
+        logoutButton.setTitle("로그아웃", for: .normal)
+        logoutButton.setTitleColor(YBColor.gray5.color, for: .normal)
+        logoutButton.titleLabel?.font = YBFont.body3.font
+//        logoutButton.addTarget(self, action: #selector(logoutButtonTapped), for: .touchUpInside)
         
-        // 두 번째 버튼 (하단)
-        let bottomButton = UIButton(type: .system)
-        bottomButton.frame = CGRect(x: 20, y: 50, width: 56, height: 40)
-        bottomButton.setTitle("회원탈퇴", for: .normal)
-        bottomButton.setTitleColor(YBColor.gray5.color, for: .normal)
-        bottomButton.titleLabel?.font = YBFont.body3.font
-        // bottomButton.addTarget(self, action: #selector(bottomButtonTapped), for: .touchUpInside)
+        let revokeButton = UIButton(type: .system)
+        revokeButton.frame = CGRect(x: 20, y: 50, width: 56, height: 40)
+        revokeButton.setTitle("회원탈퇴", for: .normal)
+        revokeButton.setTitleColor(YBColor.gray5.color, for: .normal)
+        revokeButton.titleLabel?.font = YBFont.body3.font
+//        revokeButton.addTarget(self, action: #selector(revokeButtonTapped), for: .touchUpInside)
         
-        footerView.addSubview(topButton)
-        footerView.addSubview(bottomButton)
+        footerView.addSubview(logoutButton)
+        footerView.addSubview(revokeButton)
         
         return footerView
     }

--- a/Projects/Features/MyPage/Sources/RevokeViewController.swift
+++ b/Projects/Features/MyPage/Sources/RevokeViewController.swift
@@ -1,0 +1,9 @@
+//
+//  RevokeViewController.swift
+//  MyPage
+//
+//  Created by 김태형 on 2/19/24.
+//  Copyright © 2024 YeoBee.com. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
## 이슈번호
[YB-131](https://yeobee.atlassian.net/browse/YB-131)

## 수정 사항
- 마이페이지의 프로필 수정화면(닉네임) 을 구현했습니다.
- 로그인 타입이 애플인 경우는 따로 없어서 그냥 만들었습니다 ;

## 화면 (Optional)
https://github.com/YAPP-Github/YeoBee-iOS/assets/49808034/8deedbf4-8c1c-4444-9fed-391006d2c2cf

<img src="https://github.com/YAPP-Github/YeoBee-iOS/assets/49808034/82437ace-431b-4e27-b97d-a8d091bc7b3b" width="250" height="520">



[YB-131]: https://yeobee.atlassian.net/browse/YB-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ