### PR TITLE
[YB-133] 여행 설정 변경사항 적용

### DIFF
--- a/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
+++ b/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
@@ -9,6 +9,7 @@
 import UIKit
 import UseCase
 import Entity
+import YBNetwork
 import ComposableArchitecture
 
 import ReactorKit
@@ -82,6 +83,10 @@ public final class HomeReactor: Reactor {
         Task {       
             let userResult = try await userInfoUseCase.fetchUserInfo()
             self.action.onNext(.userInfo(userResult))
+            
+            if KeychainManager.shared.load(key: "userId") == nil {
+                KeychainManager.shared.add(key: "userId", value: "\(userResult.id)")
+            }
         }
         
         Task {

--- a/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
+++ b/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
@@ -84,8 +84,8 @@ public final class HomeReactor: Reactor {
             let userResult = try await userInfoUseCase.fetchUserInfo()
             self.action.onNext(.userInfo(userResult))
             
-            if KeychainManager.shared.load(key: "userId") == nil {
-                KeychainManager.shared.add(key: "userId", value: "\(userResult.id)")
+            if KeychainManager.shared.load(key: KeychainManager.userId) == nil {
+                KeychainManager.shared.add(key: KeychainManager.userId, value: "\(userResult.id)")
             }
         }
         

--- a/Projects/Features/Setting/Sources/Presentation/Protocol/ModifiedSettingViewControllerDelegate.swift
+++ b/Projects/Features/Setting/Sources/Presentation/Protocol/ModifiedSettingViewControllerDelegate.swift
@@ -9,5 +9,6 @@
 import Foundation
 
 protocol ModifiedSettingViewControllerDelegate: AnyObject {
-    func modified()
+    func modifiedCommon()
+    func modifiedCurrency()
 }

--- a/Projects/Features/Setting/Sources/Presentation/Reactor/SettingCurrencyReactor.swift
+++ b/Projects/Features/Setting/Sources/Presentation/Reactor/SettingCurrencyReactor.swift
@@ -48,8 +48,8 @@ public final class SettingCurrencyReactor: Reactor {
         switch action {
         case .textFieldText(text: let text):
             return .just(.textFieldText(text: text))
-        case .modified(let isSucess):
-            return .just(.modified(isSucess))
+        case .modified(let isSuccess):
+            return .just(.modified(isSuccess))
         }
     }
     
@@ -65,8 +65,8 @@ public final class SettingCurrencyReactor: Reactor {
                 newState.isModifyButtonValid = false
             }
             newState.textFieldText = text
-        case .modified(let isSucess):
-            newState.isModified = isSucess
+        case .modified(let isSuccess):
+            newState.isModified = isSuccess
         }
         
         return newState

--- a/Projects/Features/Setting/Sources/Presentation/Reactor/SettingCurrencyReactor.swift
+++ b/Projects/Features/Setting/Sources/Presentation/Reactor/SettingCurrencyReactor.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 import DesignSystem
+import UseCase
+import ComposableArchitecture
 import TravelRegistration
 import Entity
 import ReactorKit
@@ -18,21 +20,27 @@ public final class SettingCurrencyReactor: Reactor {
     
     public enum Action {
         case textFieldText(text: String)
+        case modified(Bool)
     }
     
     public enum Mutation {
         case textFieldText(text: String)
+        case modified(Bool)
     }
     
     public struct State {
         var textFieldText: String = ""
         var currency: Currency
+        var tripItem: TripItem
+        var isModifyButtonValid: Bool = false
+        var isModified: Bool = false
     }
     
+    @Dependency(\.currencyUseCase) var currencyUseCase
     public var initialState: State
     
-    public init(currency: Currency) {
-        self.initialState = State(currency: currency)
+    public init(currency: Currency, tripItem: TripItem) {
+        self.initialState = State(currency: currency, tripItem: tripItem)
     }
     
     // MARK: - Mutate
@@ -40,6 +48,8 @@ public final class SettingCurrencyReactor: Reactor {
         switch action {
         case .textFieldText(text: let text):
             return .just(.textFieldText(text: text))
+        case .modified(let isSucess):
+            return .just(.modified(isSucess))
         }
     }
     
@@ -49,9 +59,53 @@ public final class SettingCurrencyReactor: Reactor {
         
         switch mutation {
         case .textFieldText(text: let text):
+            if isValidDouble(text) {
+                newState.isModifyButtonValid = true
+            } else {
+                newState.isModifyButtonValid = false
+            }
             newState.textFieldText = text
+        case .modified(let isSucess):
+            newState.isModified = isSucess
         }
         
         return newState
+    }
+    
+    func putCurrencyUseCase() {
+        Task {
+            do {
+                let currencyResult = try await currencyUseCase.putTripCurrencies(
+                    currentState.tripItem.id,
+                    currentState.currency.code,
+                    ExchangeRate(value: Double(currentState.textFieldText) ?? 0, standard: currentState.currency.exchangeRate.standard)
+                )
+                print("currencyResult: \(currencyResult)")
+                action.onNext(.modified(currencyResult))
+            } catch {
+                print("error: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    private func isValidDouble(_ input: String) -> Bool {
+        if input.isEmpty {
+            return false
+        }
+        
+        // 문자열에서 숫자와 소수점 외의 문자를 제거한 새 문자열
+        let cleanedString = input.filter { "0123456789.".contains($0) }
+        
+        // 소수점이 두 번 이상 나오는 경우 false 반환
+        if cleanedString.filter({ $0 == "." }).count > 1 {
+            return false
+        }
+        
+        // 문자열이 소수점으로 시작하거나 끝나면 false 반환
+        if cleanedString.first == "." || cleanedString.last == "." {
+            return false
+        }
+        
+        return Double(cleanedString) != nil
     }
 }

--- a/Projects/Features/Setting/Sources/Presentation/Reactor/SettingReactor.swift
+++ b/Projects/Features/Setting/Sources/Presentation/Reactor/SettingReactor.swift
@@ -86,10 +86,7 @@ public final class SettingReactor: Reactor {
             action.onNext(.companions(companions))
         }
         
-        Task {
-            let currencyResult = try await currencyUseCase.getTripCurrencies(currentTripItem.id)
-            action.onNext(.currencies(currencyResult))
-        }
+        updateCurrencyUseCase()
     }
     
     func updateSettingUseCase() {
@@ -102,6 +99,15 @@ public final class SettingReactor: Reactor {
             if companionsResult.count > 1 {
                 action.onNext(.companions(companionsResult))
             }
+        }
+    }
+    
+    func updateCurrencyUseCase() {
+        let currentTripItemId = currentState.tripItem.id
+        
+        Task {
+            let currencyResult = try await currencyUseCase.getTripCurrencies(currentTripItemId)
+            action.onNext(.currencies(currencyResult))
         }
     }
     

--- a/Projects/Features/Setting/Sources/Presentation/SubViews/SettingCompanionCell.swift
+++ b/Projects/Features/Setting/Sources/Presentation/SubViews/SettingCompanionCell.swift
@@ -100,7 +100,7 @@ class SettingCompanionCell: UITableViewCell {
         
         // 자신의 ID와 companion의 ID와 같은 경우 (동행자 자신인 경우)
         if let userId = companion.userId {
-            if String(userId) == KeychainManager.shared.load(key: "userId") {
+            if String(userId) == KeychainManager.shared.load(key: KeychainManager.userId) {
                 self.editButton.isHidden = true
             }
         }

--- a/Projects/Features/Setting/Sources/Presentation/SubViews/SettingCompanionCell.swift
+++ b/Projects/Features/Setting/Sources/Presentation/SubViews/SettingCompanionCell.swift
@@ -88,13 +88,22 @@ class SettingCompanionCell: UITableViewCell {
     }
     
     func configure() {
-        guard let companion,
-              let imageUrl = URL(string: companion.profileImageUrl ?? "\(YeoBeeAPI.shared.baseImageURL ?? "")/static/user/profile/profile0.png") else { return }
-        
-        // MARK: [TODO] 자신의 ID keychain에 저장해서 companion의 ID와 같은 경우 editButton hidden 처리
+        guard let companion else { return }
         profileNameLabel.text = companion.name
-        profileImageView.kf.indicatorType = .activity
-        profileImageView.kf.setImage(with: imageUrl)
+        
+        if let profileImageUrl = URL(string: companion.profileImageUrl ?? "") {
+            profileImageView.kf.indicatorType = .activity
+            profileImageView.kf.setImage(with: profileImageUrl)
+        } else {
+            profileImageView.image = DesignSystemAsset.Icons.face0.image
+        }
+        
+        // 자신의 ID와 companion의 ID와 같은 경우 (동행자 자신인 경우)
+        if let userId = companion.userId {
+            if String(userId) == KeychainManager.shared.load(key: "userId") {
+                self.editButton.isHidden = true
+            }
+        }
     }
     
     @objc func editButtonTapped() {

--- a/Projects/Features/Setting/Sources/Presentation/SubViews/SettingCurrencyCell.swift
+++ b/Projects/Features/Setting/Sources/Presentation/SubViews/SettingCurrencyCell.swift
@@ -80,5 +80,6 @@ class SettingCurrencyCell: UITableViewCell {
     func configure() {
         guard let currency else { return }
         currencyLabel.text = "\(currency.exchangeRate.standard) \(currency.code) = \(currency.exchangeRate.value)원"
+        nextButton.isHidden = true
     }
 }

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingCalendarViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingCalendarViewController.swift
@@ -365,7 +365,7 @@ extension SettingCalendarViewController: View {
             .map { $0.modified }
             .bind { [weak self] isSuccess in
                 if isSuccess {
-                    self?.delegate?.modified()
+                    self?.delegate?.modifiedCommon()
                     self?.navigationController?.popViewController(animated: true)
                 }
             }

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingRecycleViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingRecycleViewController.swift
@@ -181,7 +181,7 @@ extension SettingRecycleViewController: View {
             .bind { [weak self] isSuccess in
                 if isSuccess {
                     self?.navigationController?.popViewController(animated: true)
-                    self?.delegate?.modified()
+                    self?.delegate?.modifiedCommon()
                 }
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
@@ -182,12 +182,13 @@ extension SettingViewController: UITableViewDelegate {
         case .companion:
             break
         case .currency:
-            if case let .currency(currency) = snapshot.itemIdentifiers(inSection: .currency)[indexPath.item] {
-                let currentTripItem = reactor.currentState.tripItem
-                let settingCurrencyReactor = SettingCurrencyReactor(currency: currency, tripItem: currentTripItem)
-                let settingCurrencyViewController = SettingCurrencyViewController(reactor: settingCurrencyReactor)
-                self.navigationController?.pushViewController(settingCurrencyViewController, animated: true)
-            }
+            break
+//            if case let .currency(currency) = snapshot.itemIdentifiers(inSection: .currency)[indexPath.item] {
+//                let currentTripItem = reactor.currentState.tripItem
+//                let settingCurrencyReactor = SettingCurrencyReactor(currency: currency, tripItem: currentTripItem)
+//                let settingCurrencyViewController = SettingCurrencyViewController(reactor: settingCurrencyReactor)
+//                self.navigationController?.pushViewController(settingCurrencyViewController, animated: true)
+//            }
         }
     }
 }

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
@@ -183,7 +183,8 @@ extension SettingViewController: UITableViewDelegate {
             break
         case .currency:
             if case let .currency(currency) = snapshot.itemIdentifiers(inSection: .currency)[indexPath.item] {
-                let settingCurrencyReactor = SettingCurrencyReactor(currency: currency)
+                let currentTripItem = reactor.currentState.tripItem
+                let settingCurrencyReactor = SettingCurrencyReactor(currency: currency, tripItem: currentTripItem)
                 let settingCurrencyViewController = SettingCurrencyViewController(reactor: settingCurrencyReactor)
                 self.navigationController?.pushViewController(settingCurrencyViewController, animated: true)
             }
@@ -282,8 +283,12 @@ extension SettingViewController: SettingCompanionCellDelegate {
 
 // MARK: - 수정된 이후 trip update
 extension SettingViewController: ModifiedSettingViewControllerDelegate {
-    func modified() {
+    func modifiedCommon() {
         reactor.updateSettingUseCase()
+    }
+
+    func modifiedCurrency() {
+        reactor.updateCurrencyUseCase()
     }
 }
 

--- a/Projects/Repository/Sources/CurrencyRepository.swift
+++ b/Projects/Repository/Sources/CurrencyRepository.swift
@@ -13,6 +13,11 @@ import Entity
 
 public protocol CurrencyRepositoryInterface {
     func getTripCurrency(tripId: Int) async throws -> CurrencyResponse
+    func putTripCurrency(
+        _ tripId: Int,
+        _ currencyCode: String,
+        _ exchangeRate: ExchangeRate
+    ) async throws -> Bool
 }
 
 final public class CurrencyRepository: CurrencyRepositoryInterface {
@@ -22,7 +27,7 @@ final public class CurrencyRepository: CurrencyRepositoryInterface {
     let provider = MoyaProvider<CurrencyService>(plugins: [NetworkLogger()])
 
     public func getTripCurrency(tripId: Int) async throws -> CurrencyResponse {
-         let result = await provider.request(
+        let result = await provider.request(
             .getTripCurrencies(tripId: tripId)
         )
         switch result {
@@ -30,6 +35,18 @@ final public class CurrencyRepository: CurrencyRepositoryInterface {
             return try decode(data: response.data)
         case let .failure(error):
             throw error
+        }
+    }
+    
+    public func putTripCurrency(_ tripId: Int, _ currencyCode: String, _ exchangeRate: ExchangeRate) async throws -> Bool {
+        let result = await provider.request(
+            .putTripCurrencies(tripId: tripId, currencyCode: currencyCode, exchangeRate: exchangeRate)
+        )
+        switch result {
+        case .success:
+            return true
+        case .failure:
+            return false
         }
     }
 }

--- a/Projects/UseCase/Sources/CurrencyUseCase.swift
+++ b/Projects/UseCase/Sources/CurrencyUseCase.swift
@@ -14,6 +14,11 @@ import ComposableArchitecture
 
 public struct CurrencyUseCase {
     public var getTripCurrencies: @Sendable (_ tripId: Int) async throws -> [Currency]
+    public var putTripCurrencies: @Sendable (
+        _ tripId: Int,
+        _ currencyCode: String,
+        _ exchangeRate: ExchangeRate
+    ) async throws -> Bool
 }
 
 extension CurrencyUseCase: TestDependencyKey {
@@ -32,6 +37,8 @@ extension CurrencyUseCase: DependencyKey {
         let currencyRepository = CurrencyRepository()
         return .init(getTripCurrencies: { tripId in
             return try await currencyRepository.getTripCurrency(tripId: tripId).currencyList
+        }, putTripCurrencies: { tripId, currencyCode, exchangeRate in
+            return try await currencyRepository.putTripCurrency(tripId, currencyCode, exchangeRate)
         })
     }
 }

--- a/Projects/YBNetwork/Sources/KeyChainManager.swift
+++ b/Projects/YBNetwork/Sources/KeyChainManager.swift
@@ -26,6 +26,7 @@ public final class KeychainManager: KeychainManagerInterface {
     public static let refreshToken: String = "refreshToken"
     public static let accessTokenExpiredTime: String = "accessTokenExpiredTime"
     public static let refreshTokenExpiredTime: String = "refreshTokenExpiredTime"
+    public static let userId: String = "userId"
     
     private init() {}
     

--- a/Projects/YBNetwork/Sources/Service/CurrencyService.swift
+++ b/Projects/YBNetwork/Sources/Service/CurrencyService.swift
@@ -7,10 +7,12 @@
 //
 
 import Foundation
+import Entity
 import Moya
 
 public enum CurrencyService {
     case getTripCurrencies(tripId: Int)
+    case putTripCurrencies(tripId: Int, currencyCode: String, exchangeRate: ExchangeRate)
 }
 
 extension CurrencyService: TargetType {
@@ -20,6 +22,8 @@ extension CurrencyService: TargetType {
         switch self {
         case .getTripCurrencies:
             return "/v1/currencies"
+        case .putTripCurrencies(let tripId, let currencyCode, _):
+            return "/v1/currencies/\(currencyCode)/rate"
         }
     }
 
@@ -27,6 +31,8 @@ extension CurrencyService: TargetType {
         switch self {
         case .getTripCurrencies:
             return .get
+        case .putTripCurrencies:
+            return .put
         }
     }
 
@@ -34,6 +40,22 @@ extension CurrencyService: TargetType {
         switch self {
         case let .getTripCurrencies(tripId):
             return .requestParameters(parameters: ["tripId": tripId], encoding: URLEncoding.queryString)
+        case let .putTripCurrencies(tripId, currencyCode, exchangeRate):
+            let params: [String: Any] = [
+                "tripId": tripId,
+                "currencyCode": currencyCode
+            ]
+            
+            let exchangeRateResult: [String: Any] = [
+                "value": exchangeRate.value,
+                "standard": exchangeRate.standard
+            ]
+            
+            return .requestCompositeParameters(
+                bodyParameters: exchangeRateResult,
+                bodyEncoding: URLEncoding.httpBody,
+                urlParameters: params
+            )
         }
     }
 


### PR DESCRIPTION
## 이슈번호
[YB-133]

## 수정 사항
- 환율 수정 화면으로 이동하는 로직 주석처리와 > 버튼 히든처리 했습니다.
- 환율 수정 API 코드만 작성했습니다. (연결X)
- 홈 화면 내 프로필 조회 시 KeyChain에 로그인한 user의 id를 저장하는 로직을 추가했습니다.
- 여행 설정 화면의 동행자에서 자신의 userId를 확인하여 동행자 id와 비교 후 일치 시 editButton 안 보이게 처리했습니다.

## 화면 (Optional)
|여행 설정|
| --- |
|<img width="416" alt="스크린샷 2024-02-21 오전 3 21 55" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/e3645828-69fe-486e-956c-6de04c0784f8">|


## target module
- Setting

## 참고사항


[YB-133]: https://yeobee.atlassian.net/browse/YB-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ