### PR TITLE
[YB-136] YBTextButton 수정 & LaunchScreen 색상 고정

### DIFF
--- a/Projects/DesignSystem/Sources/Button/YBTextButton.swift
+++ b/Projects/DesignSystem/Sources/Button/YBTextButton.swift
@@ -85,7 +85,8 @@ extension YBTextButton.Appearance {
     var backgroundColor: YBColor {
         switch self {
         case .default: return .black
-        case .defaultDisable, .selectDisable: return .gray3
+        case .defaultDisable: return .gray3
+        case .selectDisable: return .gray2
         case .select: return .gray6
         }
     }

--- a/Projects/Features/Home/Sources/CreateAccount/CreateAccountViewController.swift
+++ b/Projects/Features/Home/Sources/CreateAccount/CreateAccountViewController.swift
@@ -22,7 +22,7 @@ public final class CreateAccountViewController: UIViewController, View {
     let nicknameLabel = YBLabel(text: "닉네임을 입력해주세요", font: .header2)
     let nicknameTextField = YBTextField()
     let errorDescriptionLabel = YBLabel(text: "", font: .body4, textColor: .mainRed)
-    let confirmButton = YBTextButton(text: "시작하기", appearance: .selectDisable, size: .medium)
+    let confirmButton = YBTextButton(text: "시작하기", appearance: .defaultDisable, size: .medium)
     
     public override func viewDidLoad() {
         super.viewDidLoad()

--- a/Projects/Features/Home/Sources/Mypage/EditMyProfileViewController.swift
+++ b/Projects/Features/Home/Sources/Mypage/EditMyProfileViewController.swift
@@ -30,7 +30,7 @@ public final class EditMyProfileViewController: UIViewController, View {
     }()
     let socialTypeLabel = YBLabel(font: .title1)
     let errorDescriptionLabel = YBLabel(text: "", font: .body4, textColor: .mainRed)
-    let editButton = YBTextButton(text: "수정하기", appearance: .selectDisable, size: .medium)
+    let editButton = YBTextButton(text: "수정하기", appearance: .defaultDisable, size: .medium)
     
     public override func viewDidLoad() {
         super.viewDidLoad()

--- a/Projects/YeoBee/Resources/LaunchScreen.storyboard
+++ b/Projects/YeoBee/Resources/LaunchScreen.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,7 +21,7 @@
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="zr1-mZ-yDA" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="Xcn-jb-7md"/>
                             <constraint firstItem="zr1-mZ-yDA" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="fc8-4b-Ch1"/>
@@ -36,8 +35,5 @@
     </scenes>
     <resources>
         <image name="launchScreen.png" width="185" height="291"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
## 이슈번호
[YB-136]

## 수정 사항
- DesignSystem YBTextButton SelectDisable 색상을 변경했습니다. (화면 버튼 참고)
- LaunchScreen 다크모드 시에 배경이 검정으로 나와서 white로 통일했습니다.

## 화면 (Optional)
|여행등록 동행자 추가|
| --- |
|<img width="386" alt="스크린샷 2024-02-22 오후 2 01 31" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/ec2de759-2652-47d5-a220-f966239e8515">|

## target module
- DesignSystem, TravelRegistration

## 참고사항


[YB-136]: https://yeobee.atlassian.net/browse/YB-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ