### PR TITLE
[YB-137] 여행 환율 설정 API 연결 & 홈 여행 날짜 Format 변경

### DIFF
--- a/Projects/Entity/Sources/API/Currency/Currency.swift
+++ b/Projects/Entity/Sources/API/Currency/Currency.swift
@@ -29,3 +29,15 @@ public struct ExchangeRate: Codable, Hashable {
         self.standard = standard
     }
 }
+
+public struct ExchangeRateRqeust: Codable {
+    public var value: Double
+    public var standard: Int
+    public var tripId: Int
+
+    public init(value: Double, standard: Int, tripId: Int) {
+        self.value = value
+        self.standard = standard
+        self.tripId = tripId
+    }
+}

--- a/Projects/Features/Expenditure/Sources/Coordinator/ExpenditureCoordinator.swift
+++ b/Projects/Features/Expenditure/Sources/Coordinator/ExpenditureCoordinator.swift
@@ -202,7 +202,7 @@ extension ExpenditureCoordinator: ExpenditureAddCoordinatorDelegate {
 
 // MARK: - 여행 삭제 후
 extension ExpenditureCoordinator: SettingCoordinatorDelegate {
-    public func deletedTrip() {
+    public func didFinishedCoordinator() {
         delegate?.deletedTrip()
     }
 }

--- a/Projects/Features/Home/Sources/Presentation/SubViews/HomeCollectionViewCell.swift
+++ b/Projects/Features/Home/Sources/Presentation/SubViews/HomeCollectionViewCell.swift
@@ -115,7 +115,7 @@ final class HomeCollectionViewCell: UICollectionViewCell {
               let flagImageUrl = URL(string: firstCountry.flagImageUrl) else { return }
         
         titleLabel.text = tripItem.title
-        dateLabel.text = "\(tripItem.startDate) - \(tripItem.endDate)"
+        dateLabel.text = "\(changeDateFormat(tripItem.startDate)) - \(changeDateFormat(tripItem.endDate))"
         countryLabel.text = firstCountry.name
         backgroundImageView.kf.indicatorType = .activity
         countryImageView.kf.indicatorType = .activity
@@ -142,5 +142,18 @@ final class HomeCollectionViewCell: UICollectionViewCell {
         
         guard let coverImageUrl = URL(string: firstCountry.coverImageUrl ?? "") else { return }
         backgroundImageView.kf.setImage(with: coverImageUrl)
+    }
+    
+    func changeDateFormat(_ dateString: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        if let date = dateFormatter.date(from: dateString) {
+            dateFormatter.dateFormat = "yyyy년 MM월 dd일"
+            let newDateString = dateFormatter.string(from: date)
+            return newDateString
+        } else {
+            return dateString
+        }
     }
 }

--- a/Projects/Features/Setting/Sources/Coordinator/SettingCoordinator.swift
+++ b/Projects/Features/Setting/Sources/Coordinator/SettingCoordinator.swift
@@ -12,7 +12,7 @@ import Coordinator
 import Entity
 
 public protocol SettingCoordinatorDelegate: AnyObject {
-    func deletedTrip()
+    func didFinishedCoordinator()
 }
 
 final public class SettingCoordinator: SettingCoordinatorInterface {
@@ -36,13 +36,14 @@ final public class SettingCoordinator: SettingCoordinatorInterface {
     }
 
     public func coordinatorDidFinish() {
+        delegate?.didFinishedCoordinator()
         navigationController.popViewController(animated: true)
         navigationController.tabBarController?.tabBar.isHidden = false
         parent?.childDidFinish(self)
     }
     
     public func deletedTrip() {
-        delegate?.deletedTrip()
+        delegate?.didFinishedCoordinator()
         coordinatorDidFinish()
         parent?.coordinatorDidFinish()
     }

--- a/Projects/Features/Setting/Sources/Presentation/Reactor/SettingCurrencyReactor.swift
+++ b/Projects/Features/Setting/Sources/Presentation/Reactor/SettingCurrencyReactor.swift
@@ -74,17 +74,12 @@ public final class SettingCurrencyReactor: Reactor {
     
     func putCurrencyUseCase() {
         Task {
-            do {
-                let currencyResult = try await currencyUseCase.putTripCurrencies(
-                    currentState.tripItem.id,
-                    currentState.currency.code,
-                    ExchangeRate(value: Double(currentState.textFieldText) ?? 0, standard: currentState.currency.exchangeRate.standard)
-                )
-                print("currencyResult: \(currencyResult)")
-                action.onNext(.modified(currencyResult))
-            } catch {
-                print("error: \(error.localizedDescription)")
-            }
+            let currencyResult = try await currencyUseCase.putTripCurrencies(
+                currentState.tripItem.id,
+                currentState.currency.code,
+                ExchangeRate(value: Double(currentState.textFieldText) ?? 0, standard: currentState.currency.exchangeRate.standard)
+            )
+            action.onNext(.modified(currencyResult))
         }
     }
     

--- a/Projects/Features/Setting/Sources/Presentation/SubViews/SettingCurrencyCell.swift
+++ b/Projects/Features/Setting/Sources/Presentation/SubViews/SettingCurrencyCell.swift
@@ -80,6 +80,5 @@ class SettingCurrencyCell: UITableViewCell {
     func configure() {
         guard let currency else { return }
         currencyLabel.text = "\(currency.exchangeRate.standard) \(currency.code) = \(currency.exchangeRate.value)원"
-        nextButton.isHidden = true
     }
 }

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingCurrencyViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingCurrencyViewController.swift
@@ -89,7 +89,7 @@ public final class SettingCurrencyViewController: UIViewController {
     private func configureBar() {
         let backImage = UIImage(systemName: "chevron.backward")?.withTintColor(YBColor.gray5.color, renderingMode: .alwaysOriginal)
         let backButton = UIBarButtonItem(image: backImage, style: .plain, target: self, action: #selector(backButtonTapped))
-        self.navigationItem.backBarButtonItem = backButton
+        self.navigationItem.leftBarButtonItem = backButton
     }
     
     @objc private func backButtonTapped() {

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
@@ -182,13 +182,12 @@ extension SettingViewController: UITableViewDelegate {
         case .companion:
             break
         case .currency:
-            break
-//            if case let .currency(currency) = snapshot.itemIdentifiers(inSection: .currency)[indexPath.item] {
-//                let currentTripItem = reactor.currentState.tripItem
-//                let settingCurrencyReactor = SettingCurrencyReactor(currency: currency, tripItem: currentTripItem)
-//                let settingCurrencyViewController = SettingCurrencyViewController(reactor: settingCurrencyReactor)
-//                self.navigationController?.pushViewController(settingCurrencyViewController, animated: true)
-//            }
+            if case let .currency(currency) = snapshot.itemIdentifiers(inSection: .currency)[indexPath.item] {
+                let currentTripItem = reactor.currentState.tripItem
+                let settingCurrencyReactor = SettingCurrencyReactor(currency: currency, tripItem: currentTripItem)
+                let settingCurrencyViewController = SettingCurrencyViewController(reactor: settingCurrencyReactor)
+                self.navigationController?.pushViewController(settingCurrencyViewController, animated: true)
+            }
         }
     }
 }

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingViewController.swift
@@ -186,6 +186,7 @@ extension SettingViewController: UITableViewDelegate {
                 let currentTripItem = reactor.currentState.tripItem
                 let settingCurrencyReactor = SettingCurrencyReactor(currency: currency, tripItem: currentTripItem)
                 let settingCurrencyViewController = SettingCurrencyViewController(reactor: settingCurrencyReactor)
+                settingCurrencyViewController.delegate = self
                 self.navigationController?.pushViewController(settingCurrencyViewController, animated: true)
             }
         }
@@ -284,11 +285,16 @@ extension SettingViewController: SettingCompanionCellDelegate {
 // MARK: - 수정된 이후 trip update
 extension SettingViewController: ModifiedSettingViewControllerDelegate {
     func modifiedCommon() {
-        reactor.updateSettingUseCase()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+            self.reactor.updateSettingUseCase()
+        }
+        
     }
 
     func modifiedCurrency() {
-        reactor.updateCurrencyUseCase()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+            self.reactor.updateCurrencyUseCase()
+        }
     }
 }
 
@@ -299,6 +305,8 @@ extension SettingViewController: YBPopupViewControllerDelegate {
     }
     
     public func actionButtonTapped() {
-        reactor.deleteTripUseCase()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+            self.reactor.deleteTripUseCase()
+        }
     }
 }

--- a/Projects/YBNetwork/Sources/Service/CurrencyService.swift
+++ b/Projects/YBNetwork/Sources/Service/CurrencyService.swift
@@ -22,7 +22,7 @@ extension CurrencyService: TargetType {
         switch self {
         case .getTripCurrencies:
             return "/v1/currencies"
-        case .putTripCurrencies(let tripId, let currencyCode, _):
+        case .putTripCurrencies(_, let currencyCode, _):
             return "/v1/currencies/\(currencyCode)/rate"
         }
     }
@@ -40,28 +40,20 @@ extension CurrencyService: TargetType {
         switch self {
         case let .getTripCurrencies(tripId):
             return .requestParameters(parameters: ["tripId": tripId], encoding: URLEncoding.queryString)
-        case let .putTripCurrencies(tripId, currencyCode, exchangeRate):
-            let params: [String: Any] = [
-                "tripId": tripId,
-                "currencyCode": currencyCode
-            ]
-            
-            let exchangeRateResult: [String: Any] = [
-                "value": exchangeRate.value,
-                "standard": exchangeRate.standard
-            ]
-            
-            return .requestCompositeParameters(
-                bodyParameters: exchangeRateResult,
-                bodyEncoding: URLEncoding.httpBody,
-                urlParameters: params
+        case let .putTripCurrencies(tripId, _, exchangeRate):
+            let exchangeRateResult = ExchangeRateRqeust(
+                value: exchangeRate.value,
+                standard: exchangeRate.standard,
+                tripId: tripId
             )
+            
+            return .requestJSONEncodable(exchangeRateResult)
         }
     }
 
     public var headers: [String : String]? {
         if let token = KeychainManager.shared.load(key: KeychainManager.accessToken) {
-            return ["Authorization": "Bearer \(token)"]
+            return ["Content-type": "application/json", "Authorization": "Bearer \(token)"]
         } else {
             return nil
         }


### PR DESCRIPTION
## 이슈번호
[YB-137]

## 수정 사항
- 여행 환율 설정 API 연결했습니다.
- 홈 셀에서 날짜를 년, 월, 일로 변경했습니다.
- SettingCoordinator에서 ExpenditureCoordinator로 Setting이 나갈 때와 여행이 삭제되었을 때 Delegate를 전달하는 것으로 수정했습니다. 

(메서드 명을 deletedTrip -> didFinishedCoordinator 변경했는데 혼란이 있는 부분이 있으면 바로 말씀해주세요!)


## 화면 (Optional)
| 홈 날짜 변경 | 여행 환율 설정 |
| --- | --- |
|<img width="387" alt="스크린샷 2024-02-23 오후 8 12 09" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/70c35074-9c17-49fd-8a5a-e688c5535f6d">| <img width="387" alt="스크린샷 2024-02-23 오후 8 14 09" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/07f0b17b-1dd4-46a5-96ed-f2ada9d7d54e"> |



## target module
- Setting
- Home



## 참고사항
- ExpenditureCoordinatorDelegate, TripCoordinatorDelegate에 `deletedTrip` 함수명을 적절한 함수명으로 변경해야 할 것 같아요!


[YB-137]: https://yeobee.atlassian.net/browse/YB-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ