### PR TITLE
[YB-138] popup Layout 이슈 해결 & 환율 설정 popup 추가 & 나라 선택 디자인 피드백 반영

### DIFF
--- a/Projects/DesignSystem/Sources/Popup/PopupViewController+Demo.swift
+++ b/Projects/DesignSystem/Sources/Popup/PopupViewController+Demo.swift
@@ -133,7 +133,7 @@ public class PopupViewController: DesignSystemBaseViewController {
     
     @objc
     func expenseSettingButtonTapped() {
-        let vc = YBPopupTypeViewController(popupType: .expenseSetting)
+        let vc = YBPopupTypeViewController(popupType: .currencySetting)
         vc.delegate = self
         presentPopup(presentedViewController: vc)
     }

--- a/Projects/DesignSystem/Sources/Popup/YBPopupType.swift
+++ b/Projects/DesignSystem/Sources/Popup/YBPopupType.swift
@@ -15,7 +15,7 @@ public enum YBPopupType {
     case logout
     case expenseDelete
     case tripDelete
-    case expenseSetting
+    case currencySetting
 }
 
 extension YBPopupType {
@@ -27,7 +27,7 @@ extension YBPopupType {
         case .logout: DesignSystemAsset.Icons.lock.image
         case .expenseDelete: DesignSystemAsset.Icons.trashBadge.image
         case .tripDelete: DesignSystemAsset.Icons.trashBadge.image
-        case .expenseSetting: nil
+        case .currencySetting: nil
         }
     }
 
@@ -39,7 +39,7 @@ extension YBPopupType {
         case .logout: return "정말 로그아웃 하시겠어요?"
         case .expenseDelete: return "정말 삭제 하시겠어요?"
         case .tripDelete: return "정말 여행을 삭제하시겠어요?"
-        case .expenseSetting: return "환율을 변경하면 이전 항목까지\n 전부 변경된 값으로 저장돼요."
+        case .currencySetting: return "환율을 변경하면 이전 항목까지\n 전부 변경된 값으로 저장돼요."
         }
     }
 
@@ -51,7 +51,7 @@ extension YBPopupType {
         case .logout: return "로그아웃 시 서비스 이용이 불가해요."
         case .expenseDelete: return "삭제한 후에는 복구가 불가해요."
         case .tripDelete: return "삭제한 후에는 복구가 불가해요."
-        case .expenseSetting: return "계속해서 변경하시겠어요?"
+        case .currencySetting: return "계속해서 변경하시겠어요?"
         }
     }
 }

--- a/Projects/DesignSystem/Sources/Popup/YBPopupTypeViewController.swift
+++ b/Projects/DesignSystem/Sources/Popup/YBPopupTypeViewController.swift
@@ -69,7 +69,7 @@ final public class YBPopupTypeViewController: YBPopupViewController {
         case .tripDelete:
             cancelButton.setTitle("취소하기", for: .normal)
             actionButton.setTitle("삭제하기", for: .normal)
-        case .expenseSetting:
+        case .currencySetting:
             cancelButton.setTitle("취소하기", for: .normal)
             actionButton.setTitle("변경하기", for: .normal)
             titleMessageLabel.numberOfLines = 2
@@ -134,7 +134,7 @@ final public class YBPopupTypeViewController: YBPopupViewController {
                 make.width.equalTo(49)
                 make.height.equalTo(56)
             }
-        case .expenseSetting:
+        case .currencySetting:
             break
         }
     }

--- a/Projects/DesignSystem/Sources/Popup/YBPopupViewController.swift
+++ b/Projects/DesignSystem/Sources/Popup/YBPopupViewController.swift
@@ -41,13 +41,13 @@ public class YBPopupViewController: UIViewController {
         switch popupType {
         case .addCommonBudget, .addTotalBudget, .calendarWarning, .logout, .expenseDelete, .tripDelete:
             sheetContentView.snp.makeConstraints { make in
-                make.height.equalTo(UIScreen.main.bounds.height * 0.358)
+                make.height.equalTo(291)
                 make.leading.trailing.equalToSuperview().inset(24)
                 make.center.equalToSuperview()
             }
         case .expenseSetting:
             sheetContentView.snp.makeConstraints { make in
-                make.height.equalTo(UIScreen.main.bounds.height * 0.27)
+                make.height.equalTo(236)
                 make.leading.trailing.equalToSuperview().inset(24)
                 make.center.equalToSuperview()
             }

--- a/Projects/DesignSystem/Sources/Popup/YBPopupViewController.swift
+++ b/Projects/DesignSystem/Sources/Popup/YBPopupViewController.swift
@@ -45,7 +45,7 @@ public class YBPopupViewController: UIViewController {
                 make.leading.trailing.equalToSuperview().inset(24)
                 make.center.equalToSuperview()
             }
-        case .expenseSetting:
+        case .currencySetting:
             sheetContentView.snp.makeConstraints { make in
                 make.height.equalTo(236)
                 make.leading.trailing.equalToSuperview().inset(24)

--- a/Projects/Features/Setting/Sources/Presentation/ViewController/SettingCurrencyViewController.swift
+++ b/Projects/Features/Setting/Sources/Presentation/ViewController/SettingCurrencyViewController.swift
@@ -117,7 +117,9 @@ extension SettingCurrencyViewController: View {
         modifyButton.rx.tap
             .observe(on: MainScheduler.instance)
             .bind { [weak self] in
-                self?.reactor.putCurrencyUseCase()
+                let popupViewController = YBPopupTypeViewController(popupType: .currencySetting)
+                popupViewController.delegate = self
+                self?.presentPopup(presentedViewController: popupViewController)
             }
             .disposed(by: disposeBag)
     }
@@ -222,5 +224,15 @@ extension SettingCurrencyViewController: UIGestureRecognizerDelegate {
             return false
         }
         return true
+    }
+}
+
+extension SettingCurrencyViewController: YBPopupViewControllerDelegate {
+    public func cancelButtonTapped() {
+        return
+    }
+    
+    public func actionButtonTapped() {
+        reactor.putCurrencyUseCase()
     }
 }

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Country/CountryViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Country/CountryViewController.swift
@@ -40,7 +40,8 @@ public final class CountryViewController: UIViewController {
     private let countryTableView = CountryTableView()
     private let horizontalCountryView = HorizontalCountryView()
     private let selectedCountryView = SelectedCountryView()
-    private let dividerView = YBDivider(height: 0.6, color: .gray3)
+    private let topDividerView = YBDivider(height: 0.6, color: .gray3)
+    private let bottomDividerView = YBDivider(height: 0.6, color: .gray3)
     private let nextButton = YBTextButton(text: "다음으로", appearance: .defaultDisable, size: .medium)
     private let emptyView = YBEmptyView(title: "검색 결과가 없어요.")
     
@@ -74,7 +75,8 @@ public final class CountryViewController: UIViewController {
             horizontalCountryView,
             countryTableView,
             selectedCountryView,
-            dividerView,
+            topDividerView,
+            bottomDividerView,
             nextButton,
             emptyView
         ].forEach {
@@ -86,25 +88,29 @@ public final class CountryViewController: UIViewController {
         horizontalCountryView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(80)
+            make.height.equalTo(73)
         }
         nextButton.snp.makeConstraints { make in
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(10)
             make.leading.trailing.equalToSuperview().inset(24)
         }
-        dividerView.snp.makeConstraints { make in
+        topDividerView.snp.makeConstraints { make in
+            make.top.equalTo(horizontalCountryView.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+        }
+        bottomDividerView.snp.makeConstraints { make in
             make.bottom.equalTo(nextButton.snp.top).inset(-16)
             make.leading.trailing.equalToSuperview()
         }
         selectedCountryView.snp.makeConstraints { make in
-            make.bottom.equalTo(dividerView.snp.top)
+            make.bottom.equalTo(bottomDividerView.snp.top)
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(111)
         }
         countryTableView.snp.makeConstraints { make in
             make.top.equalTo(horizontalCountryView.snp.bottom)
             make.leading.trailing.equalToSuperview()
-            make.bottom.equalTo(dividerView.snp.top)
+            make.bottom.equalTo(bottomDividerView.snp.top)
         }
         emptyView.snp.makeConstraints { make in
             make.edges.equalTo(countryTableView.snp.edges)
@@ -117,7 +123,7 @@ public final class CountryViewController: UIViewController {
             countryTableView.snp.remakeConstraints { make in
                 make.top.equalTo(horizontalCountryView.snp.bottom)
                 make.leading.trailing.equalToSuperview()
-                make.bottom.equalTo(dividerView.snp.top)
+                make.bottom.equalTo(bottomDividerView.snp.top)
             }
         } else {
             selectedCountryView.alpha = 1

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Country/SubViews/HorizontalCountryView.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Country/SubViews/HorizontalCountryView.swift
@@ -22,7 +22,6 @@ class HorizontalCountryView: UIScrollView {
         $0.backgroundColor = .clear
         return $0
     }(UIStackView())
-    private let dividerView = YBDivider(height: 0.6, color: .gray3)
     
     var selectedButton: UIButton?
     var disposeBag = DisposeBag()
@@ -58,15 +57,11 @@ class HorizontalCountryView: UIScrollView {
     
     private func addViews() {
         addSubview(stackView)
-        addSubview(dividerView)
     }
     private func setLayout() {
         stackView.snp.makeConstraints { make in
-            make.top.bottom.centerY.equalToSuperview()
-            make.leading.trailing.equalToSuperview().inset(24)
-        }
-        dividerView.snp.makeConstraints { make in
-            make.leading.trailing.bottom.equalToSuperview()
+            make.top.equalToSuperview().inset(13)
+            make.leading.trailing.bottom.equalToSuperview().inset(24)
         }
     }
     


### PR DESCRIPTION
## 이슈번호
[YB-138]

## 수정 사항
- SE 기종 popup 레이아웃 오류 height 고정 값으로 줘서 해결했습니다.
- 환율 설정할 때 확인 popup 추가했습니다.
- 나라 선택 화면 태그 부분 간격 수정해달라는 피드백 반영해서 올렸습니다.
**(사진 참고)**

## 화면 (Optional)
|기본 공통 팝업|환율 변경 팝업|나라 선택 화면|
| --- | --- | --- |
|<img width="397" alt="스크린샷 2024-02-24 오전 1 14 23" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/0dcc78d5-44bb-4951-a5dd-9930f8688226">|<img width="397" alt="스크린샷 2024-02-24 오전 1 14 13" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/c36a1bd2-34f6-4fea-a7f8-c5c6cb18ba4e">|<img width="397" alt="스크린샷 2024-02-24 오전 1 54 11" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/e7e44981-4d79-47db-a530-96d48eecf9dd">|


## target module


## 참고사항
