### PR TITLE
[YB-140] 여행 설정 원화 환율 변경 삭제

### DIFF
--- a/Projects/Features/Setting/Sources/Presentation/Reactor/SettingReactor.swift
+++ b/Projects/Features/Setting/Sources/Presentation/Reactor/SettingReactor.swift
@@ -107,7 +107,15 @@ public final class SettingReactor: Reactor {
         
         Task {
             let currencyResult = try await currencyUseCase.getTripCurrencies(currentTripItemId)
-            action.onNext(.currencies(currencyResult))
+            var exceptKRWCurrencyResult: [Currency] = []
+            
+            for currency in currencyResult {
+                if !(currency.code == "KRW") {
+                    exceptKRWCurrencyResult.append(currency)
+                }
+            }
+            
+            action.onNext(.currencies(exceptKRWCurrencyResult))
         }
     }
     


### PR DESCRIPTION
## 이슈번호
[YB-140]

## 수정 사항
- 여행 설정에서 원화 환율은 빼고 반영되도록 변경했습니다. 

## 화면 (Optional)
|여행 설정|
| --- |
|<img width="447" alt="스크린샷 2024-03-05 오전 11 44 22" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/332dda86-a499-4f7e-aa0b-a23398b5ba74">|



## target module
- Setting

## 참고사항


[YB-140]: https://yeobee.atlassian.net/browse/YB-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ