### PR TITLE
[YB-141] Coordinator 리펙토링 & Section 업데이트

### DIFF
--- a/Projects/Features/Home/Sources/Coordinator/HomeCoordinator.swift
+++ b/Projects/Features/Home/Sources/Coordinator/HomeCoordinator.swift
@@ -14,7 +14,7 @@ import TravelRegistration
 import Trip
 
 public protocol HomeCoordinatorDelegate: AnyObject {
-    func finishedRegistration()
+    func finishedRegistration(tripItem: TripItem)
     func deletedTrip()
 }
 
@@ -67,8 +67,8 @@ extension HomeCoordinator {
 }
 
 extension HomeCoordinator: TravelRegistrationCoordinatorDelegate {
-    public func finishedRegistration() {
-        delegate?.finishedRegistration()
+    public func finishedRegistration(tripItem: TripItem) {
+        delegate?.finishedRegistration(tripItem: tripItem)
     }
 }
 

--- a/Projects/Features/Home/Sources/Coordinator/HomeCoordinator.swift
+++ b/Projects/Features/Home/Sources/Coordinator/HomeCoordinator.swift
@@ -43,6 +43,13 @@ extension HomeCoordinator {
         addChild(countryCoordinator)
         countryCoordinator.start(animated: true)
     }
+    
+    public func moreTrip(tripType: TripType) {
+        let moreTripReactor = MoreTripReactor(tripType: tripType)
+        let moreTripViewController = MoreTripViewController(coordinator: self, reactor: moreTripReactor)
+        navigationController.isNavigationBarHidden = false
+        navigationController.pushViewController(moreTripViewController, animated: true)
+    }
 
     public func trip(tripItem: TripItem) {
         let tripCoordinator = TripCoordinator(navigationController: navigationController, tripItem: tripItem)
@@ -67,6 +74,9 @@ extension HomeCoordinator: TravelRegistrationCoordinatorDelegate {
 
 extension HomeCoordinator: TripCoordinatorDelegate {
     public func deletedTrip() {
+        // 스플래시, 홈 포함 뷰 스택 2개
+        let targetViewControllers = Array(navigationController.viewControllers.prefix(2))
+        navigationController.setViewControllers(targetViewControllers, animated: true)
         delegate?.deletedTrip()
     }
 }

--- a/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
+++ b/Projects/Features/Home/Sources/Presentation/Reactor /HomeReactor.swift
@@ -79,8 +79,8 @@ public final class HomeReactor: Reactor {
         return newState
     }
     
-    func homeTripUseCase() {
-        Task {       
+    func homeInitUseCase() {
+        Task {
             let userResult = try await userInfoUseCase.fetchUserInfo()
             self.action.onNext(.userInfo(userResult))
             
@@ -88,7 +88,10 @@ public final class HomeReactor: Reactor {
                 KeychainManager.shared.add(key: KeychainManager.userId, value: "\(userResult.id)")
             }
         }
-        
+        homeTripUseCase()
+    }
+    
+    func homeTripUseCase() {
         Task {
             let pastResult = try await tripUseCase.getPastTrip(0, 3)
             let tripItems = pastResult.content

--- a/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
@@ -334,12 +334,7 @@ extension HomeViewController: HomeSectionHeaderViewDelegate {
             if let coordinator = coordinator,
                let firstCharacter = tripType.first,
                tripTypeCase.rawValue.first == firstCharacter {
-                
-                let moreTripReactor = MoreTripReactor(tripType: tripTypeCase)
-                let moreTripViewController = MoreTripViewController(coordinator: coordinator, reactor: moreTripReactor)
-                moreTripViewController.delegate = self
-                navigationController?.isNavigationBarHidden = false
-                navigationController?.pushViewController(moreTripViewController, animated: true)
+                coordinator.moreTrip(tripType: tripTypeCase)
             }
         }
     }
@@ -356,15 +351,6 @@ extension HomeViewController: HomeCoordinatorDelegate {
     }
     
     public func deletedTrip() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-            self.reactor.homeTripUseCase()
-        }
-    }
-}
-
-// MARK: - 더보기에서 들어가 삭제된 경우
-extension HomeViewController: MoreTripViewControllerDelegate {
-    func updateHomeTrip() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
             self.reactor.homeTripUseCase()
         }

--- a/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/HomeViewController.swift
@@ -158,7 +158,7 @@ public final class HomeViewController: UIViewController {
                             // 현재 날짜와 startDate 차이 계산
                             if let startDate = dateFormatter.date(from: tripItem.startDate) {
                                 if let daysDiff = Calendar.current.dateComponents([.day], from: Date(), to: startDate).day {
-                                    header.sectionTitleLabel.text = "\(TripType.coming.rawValue), D-\(daysDiff)"
+                                    header.sectionTitleLabel.text = "\(TripType.coming.rawValue), D-\(daysDiff + 1)"
                                     if self.reactor.currentState.comingTrip.count > 1 {
                                         header.moreButton.isHidden = false
                                     }
@@ -219,7 +219,7 @@ public final class HomeViewController: UIViewController {
                     if let comingTrip = reactor.currentState.comingTrip.first {
                         if let startDate = dateFormatter.date(from: comingTrip.startDate) {
                             let daysDiff = Calendar.current.dateComponents([.day], from: Date(), to: startDate).day ?? 0
-                            header.sectionTitleLabel.text = "\(TripType.coming.rawValue), D-\(daysDiff)"
+                            header.sectionTitleLabel.text = "\(TripType.coming.rawValue), D-\(daysDiff + 1)"
                             header.moreButton.isHidden = reactor.currentState.comingTrip.count <= 1
                         }
                     }
@@ -342,11 +342,12 @@ extension HomeViewController: HomeSectionHeaderViewDelegate {
 
 // MARK: - 여행 등록 & 삭제 완료 후
 extension HomeViewController: HomeCoordinatorDelegate {
-    public func finishedRegistration() {
+    public func finishedRegistration(tripItem: TripItem) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
             let toast = Toast.text(icon: .complete, "새로운 여행이 등록 되었어요!")
             toast.show()
             self.reactor.homeTripUseCase()
+            self.coordinator?.trip(tripItem: tripItem)
         }
     }
     

--- a/Projects/Features/Home/Sources/Presentation/ViewController/MoreTripViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/MoreTripViewController.swift
@@ -184,8 +184,8 @@ extension MoreTripViewController: HomeCoordinatorDelegate {
     
     public func deletedTrip() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.navigationController?.popViewController(animated: true)
             self.delegate?.updateHomeTrip()
+            self.navigationController?.popViewController(animated: true)
         }
     }
 }

--- a/Projects/Features/Home/Sources/Presentation/ViewController/MoreTripViewController.swift
+++ b/Projects/Features/Home/Sources/Presentation/ViewController/MoreTripViewController.swift
@@ -23,17 +23,12 @@ enum MoreTripDataItem: Hashable {
     case main(TripItem)
 }
 
-protocol MoreTripViewControllerDelegate: AnyObject {
-    func updateHomeTrip()
-}
-
 public final class MoreTripViewController: UIViewController {
     
     public var disposeBag = DisposeBag()
     private let reactor: MoreTripReactor
     private var dataSource: UICollectionViewDiffableDataSource<MoreTripSection, MoreTripDataItem>?
     let coordinator: HomeCoordinator
-    weak var delegate: MoreTripViewControllerDelegate?
     
     // MARK: - Properties
     lazy var moreTripCollectionView = HomeCollectionView()
@@ -64,7 +59,6 @@ public final class MoreTripViewController: UIViewController {
     // MARK: - Set UI
     private func setView() {
         moreTripCollectionView.delegate = self
-        coordinator.delegate = self
     }
     
     private func addViews() {
@@ -174,18 +168,5 @@ extension MoreTripViewController: View {
                 self?.configureSnapshot(tripItems: tripItems)
             }
             .disposed(by: disposeBag)
-    }
-}
-
-extension MoreTripViewController: HomeCoordinatorDelegate {
-    public func finishedRegistration() {
-        return
-    }
-    
-    public func deletedTrip() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.delegate?.updateHomeTrip()
-            self.navigationController?.popViewController(animated: true)
-        }
     }
 }

--- a/Projects/Features/Setting/Sources/Coordinator/SettingCoordinator.swift
+++ b/Projects/Features/Setting/Sources/Coordinator/SettingCoordinator.swift
@@ -36,7 +36,6 @@ final public class SettingCoordinator: SettingCoordinatorInterface {
     }
 
     public func coordinatorDidFinish() {
-        delegate?.didFinishedCoordinator()
         navigationController.popViewController(animated: true)
         navigationController.tabBarController?.tabBar.isHidden = false
         parent?.childDidFinish(self)

--- a/Projects/Features/TravelRegistration/Sources/Coordinator/TravelRegistrationCoordinator.swift
+++ b/Projects/Features/TravelRegistration/Sources/Coordinator/TravelRegistrationCoordinator.swift
@@ -12,7 +12,7 @@ import Coordinator
 import Entity
 
 public protocol TravelRegistrationCoordinatorDelegate: AnyObject {
-    func finishedRegistration()
+    func finishedRegistration(tripItem: TripItem)
 }
 
 final public class TravelRegistrationCoordinator: TravelRegistrationCoordinatorInterface {
@@ -42,8 +42,8 @@ final public class TravelRegistrationCoordinator: TravelRegistrationCoordinatorI
         parent?.childDidFinish(self)
     }
     
-    public func finishedRegistration() {
-        delegate?.finishedRegistration()
+    public func finishedRegistration(tripItem: TripItem) {
+        delegate?.finishedRegistration(tripItem: tripItem)
         coordinatorDidFinish()
     }
 

--- a/Projects/Features/TravelRegistration/Sources/Coordinator/TravelRegistrationCoordinator.swift
+++ b/Projects/Features/TravelRegistration/Sources/Coordinator/TravelRegistrationCoordinator.swift
@@ -51,3 +51,23 @@ final public class TravelRegistrationCoordinator: TravelRegistrationCoordinatorI
         print("TravelRegistrationCoordinator is de-initialized.")
     }
 }
+
+extension TravelRegistrationCoordinator {
+    public func startCalendar(tripRequest: RegistTripRequest) {
+        let calendarReactor = CalendarReactor(tripRequest: tripRequest)
+        let calendarViewController = CalendarViewController(coordinator: self, reactor: calendarReactor)
+        travelRegistrationNavigationController?.pushViewController(calendarViewController, animated: true)
+    }
+    
+    public func startCompanion(tripRequest: RegistTripRequest) {
+        let companionReactor = CompanionReactor(tripRequest: tripRequest)
+        let companionViewController = CompanionViewController(coordinator: self, reactor: companionReactor)
+        travelRegistrationNavigationController?.pushViewController(companionViewController, animated: true)
+    }
+    
+    public func startTravelTitle(tripRequest: RegistTripRequest) {
+        let travelTtitleReactor = TravelTitleReactor(tripRequest: tripRequest)
+        let travelTitleViewController = TravelTitleViewController(coordinator: self, reactor: travelTtitleReactor)
+        travelRegistrationNavigationController?.pushViewController(travelTitleViewController, animated: true)
+    }
+}

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Calendar/CalendarViewController.swift
@@ -333,10 +333,7 @@ extension CalendarViewController: View {
                         countryList: self.reactor.currentState.tripRequest.countryList,
                         tripUserList: [])
                     
-                    let companionReactor = CompanionReactor(tripRequest: tripRequest)
-                    let companionViewController = CompanionViewController(coordinator: self.coordinator,
-                                                                          reactor: companionReactor)
-                    self.navigationController?.pushViewController(companionViewController, animated: true)
+                    self.coordinator.startCompanion(tripRequest: tripRequest)
                 }
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Companion/ViewController/CompanionViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Companion/ViewController/CompanionViewController.swift
@@ -250,10 +250,7 @@ extension CompanionViewController: View {
                         tripUserList: tripUserList
                     )
                     
-                    let travelTtitleReactor = TravelTitleReactor(tripRequest: tripRequest)
-                    let travelTitleViewController = TravelTitleViewController(coordinator: self.coordinator, 
-                                                                              reactor: travelTtitleReactor)
-                    self.navigationController?.pushViewController(travelTitleViewController, animated: true)
+                    self.coordinator.startTravelTitle(tripRequest: tripRequest)
                 case .alone:
                     let currentTripRequest = self.reactor.currentState.tripRequest
                     let tripRequest = RegistTripRequest(
@@ -263,10 +260,8 @@ extension CompanionViewController: View {
                         countryList: currentTripRequest.countryList,
                         tripUserList: []
                     )
-                    let travelTtitleReactor = TravelTitleReactor(tripRequest: tripRequest)
-                    let travelTitleViewController = TravelTitleViewController(coordinator: self.coordinator, 
-                                                                              reactor: travelTtitleReactor)
-                    self.navigationController?.pushViewController(travelTitleViewController, animated: true)
+                    
+                    self.coordinator.startTravelTitle(tripRequest: tripRequest)
                 }
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/TravelRegistration/Sources/Presentation/Country/CountryViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/Country/CountryViewController.swift
@@ -301,10 +301,7 @@ extension CountryViewController: View {
                     countryList: selectedCountries,
                     tripUserList: []
                 )
-                
-                let calendarReactor = CalendarReactor(tripRequest: tripRequest)
-                let calendarViewController = CalendarViewController(coordinator: self.coordinator, reactor: calendarReactor)
-                self.navigationController?.pushViewController(calendarViewController, animated: true)
+                self.coordinator.startCalendar(tripRequest: tripRequest)
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/TravelRegistration/Sources/Presentation/TravelTitle/TravelTitleViewController.swift
+++ b/Projects/Features/TravelRegistration/Sources/Presentation/TravelTitle/TravelTitleViewController.swift
@@ -155,10 +155,10 @@ extension TravelTitleViewController: View {
             .disposed(by: disposeBag)
         
         reactor.state
-            .map { $0.postValidation }
-            .bind { [weak self] isSuccess in
-                if isSuccess {
-                    self?.coordinator.finishedRegistration()
+            .map { $0.postResult }
+            .bind { [weak self] tripItem in
+                if let tripItem {
+                    self?.coordinator.finishedRegistration(tripItem: tripItem)
                     self?.navigationController?.dismiss(animated: true)
                 }
             }


### PR DESCRIPTION
## 이슈번호
[YB-141]


## 수정 사항
- 더보기, 여행 등록 화면 전환 로직 coordinator 안으로 넣었습니다.
- 기존에 여행 추가/삭제 했을 때 section 업데이트 안 되는 오류 해결했습니다.
- 여행 등록 후 가게부로 화면 전환 로직 추가했습니다.


## 화면 (Optional)
|section 재설정|여행등록 후 가게부로 이동|
| --- | --- |
|<img width="330" alt="스크린샷 2024-03-07 오후  3 14 23" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/2cd56fda-a816-4758-9f39-1155a5939686">| <img width="330" alt="스크린샷 2024-03-08 오후  1 01 17" src="https://github.com/YAPP-Github/YeoBee-iOS/assets/82807263/5fef93e0-c3af-415b-9cb2-e99e0e79a977">|


## target module
- Home
- TravelRegistration

## 참고사항


[YB-141]: https://yeobee.atlassian.net/browse/YB-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ